### PR TITLE
Fix canvas scaling on high-DPI devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,33 +408,31 @@ let canvasOffsetX = 0;
 let canvasOffsetY = 0;
 
 function updateCanvasScale() {
-  const rect = canvas.getBoundingClientRect();
   const containerWidth = canvas.parentElement.offsetWidth;
-  
+
   // Calculate scale based on container width vs canvas native width
   scale = Math.min(1, containerWidth / 980);
-  
+
   // Update canvas display size while keeping internal resolution
   const displayWidth = 980 * scale;
   const displayHeight = 560 * scale;
-  
+
   canvas.style.width = displayWidth + 'px';
   canvas.style.height = displayHeight + 'px';
-  
-  // Handle high DPI displays
+
+  // Handle high DPI displays - reset transform each call to avoid cumulative scaling
   const dpr = window.devicePixelRatio || 1;
-  if (dpr > 1 && scale < 1) {
-    // For high DPI mobile devices, use device pixel ratio for crisp rendering
-    const scaledDpr = Math.min(dpr, 2); // Cap at 2x to avoid too much memory usage
-    canvas.width = 980 * scaledDpr;
-    canvas.height = 560 * scaledDpr;
-    ctx.scale(scaledDpr, scaledDpr);
-    
-    // Update constants used in drawing
-    W = 980; // Keep logical coordinates the same
-    H = 560;
-  }
-  
+  const scaledDpr = (dpr > 1 && scale < 1) ? Math.min(dpr, 2) : 1;
+
+  // Resize internal canvas resolution and reset transform
+  canvas.width = 980 * scaledDpr;
+  canvas.height = 560 * scaledDpr;
+  ctx.setTransform(scaledDpr, 0, 0, scaledDpr, 0, 0);
+
+  // Update constants used in drawing
+  W = 980;
+  H = 560;
+
   // Store offsets for coordinate conversion
   const newRect = canvas.getBoundingClientRect();
   canvasOffsetX = newRect.left;
@@ -450,9 +448,11 @@ function getCanvasCoordinates(clientX, clientY) {
 }
 
 // Initialize canvas scaling
-window.addEventListener('resize', updateCanvasScale);
-window.addEventListener('load', updateCanvasScale);
-updateCanvasScale();
+window.addEventListener('resize', () => {
+  updateCanvasScale();
+  // Redraw current state after resize to keep canvas content visible
+  if (matchState || forgeState) draw();
+});
 
 const MODES = { MATCH:'MATCH', FORGE:'FORGE' };
 let mode = MODES.MATCH;                  // current game mode


### PR DESCRIPTION
## Summary
- Remove load-time canvas scaling that cleared the game after initialization
- Redraw canvas after window resize to keep content visible

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1a38b170832085f0921c623f9d2d