### PR TITLE
Add Latvian aria labels for buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
   <div id="ui">
     <button id="mode-match" class="pill">▶ Match Rush</button>
     <button id="mode-forge" class="pill">▶ Prefix Forge</button>
-    <button id="btn-practice" class="ghost">Practice</button>
-    <button id="btn-challenge" class="ghost">Challenge</button>
-    <button id="btn-prev" class="outline small">⟨</button>
-    <button id="btn-next" class="outline small">⟩</button>
-    <button id="btn-deck-size" class="outline small" title="Toggle deck size">📏</button>
-    <button id="btn-export" class="ok">Export Results (CSV)</button>
-    <button id="btn-help" class="ghost">Help</button>
+    <button id="btn-practice" class="ghost" aria-label="Praktizēties">Practice</button>
+    <button id="btn-challenge" class="ghost" aria-label="Izaicinājums">Challenge</button>
+    <button id="btn-prev" class="outline small" aria-label="Iepriekšējā kartīte">⟨</button>
+    <button id="btn-next" class="outline small" aria-label="Nākamā kartīte">⟩</button>
+    <button id="btn-deck-size" class="outline small" title="Pārslēgt kavas izmēru" aria-label="Pārslēgt kavas izmēru">📏</button>
+    <button id="btn-export" class="ok" aria-label="Eksportēt rezultātus CSV formātā">Export Results (CSV)</button>
+    <button id="btn-help" class="ghost" aria-label="Palīdzība">Help</button>
     <span id="status" style="margin-left:auto;font-weight:700;"></span>
   </div>
 


### PR DESCRIPTION
## Summary
- add Latvian `aria-label` attributes to navigation, export, and other control buttons
- localize deck size tooltip text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe95a5ec48320889371455a55bd39