### PR TITLE
Load vocabulary from external JSON

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,212 +16,7 @@
 /* =====================
    DATA: vocabulary & prefix hints (LV→EN)
    ===================== */
-const DATA = {
-  units: [
-    {
-      name: "Mainīt / Mainīties ģimene",
-      entries: [
-        {lv:"mainīt", en:"to change (something)", tags:["base"]},
-        {lv:"mainīties", en:"to change (oneself)/change state", tags:["reflexive"]},
-        {lv:"izmainīt", en:"to alter; to change completely", tags:["prefix:iz"]},
-        {lv:"pārmainīt", en:"to transform; change over", tags:["prefix:pār"]},
-        {lv:"nomainīt", en:"to replace; change out", tags:["prefix:no"]},
-        {lv:"samainīt", en:"to swap; to exchange", tags:["prefix:sa"]},
-        {lv:"apmainīt", en:"to exchange; to switch", tags:["prefix:ap"]}
-      ]
-    },
-    {
-      name: "Braukt ar priedēkļiem",
-      entries: [
-        {lv:"braukt", en:"to go (by transport)", tags:["base"]},
-        {lv:"atbraukt", en:"to arrive (come)", tags:["prefix:at"]},
-        {lv:"aizbraukt", en:"to leave, go away", tags:["prefix:aiz"]},
-        {lv:"iebraukt", en:"to enter (drive into)", tags:["prefix:ie"]},
-        {lv:"izbraukt", en:"to go out (drive out)", tags:["prefix:iz"]},
-        {lv:"piebraukt", en:"to drive up to", tags:["prefix:pie"]},
-        {lv:"apbraukt", en:"to drive around", tags:["prefix:ap"]},
-        {lv:"pārbraukt", en:"to drive over / across", tags:["prefix:pār"]},
-        {lv:"nobraukt", en:"to drive down / run over", tags:["prefix:no"]},
-        {lv:"uzbraukt", en:"to drive up (onto)", tags:["prefix:uz"]},
-        {lv:"sabraukt", en:"to gather (arrive by vehicles)", tags:["prefix:sa"]}
-      ]
-    },
-    {
-      name: "Iet ar priedēkļiem",
-      entries: [
-        {lv:"iet", en:"to go (on foot)", tags:["base"]},
-        {lv:"ieiet", en:"to go in, enter", tags:["prefix:ie"]},
-        {lv:"iziet", en:"to go out, exit", tags:["prefix:iz"]},
-        {lv:"aiziet", en:"to leave, go away", tags:["prefix:aiz"]},
-        {lv:"atiet", en:"to depart (train, bus)", tags:["prefix:at"]},
-        {lv:"pieiet", en:"to approach, go up to", tags:["prefix:pie"]},
-        {lv:"pāriet", en:"to cross, to switch", tags:["prefix:pār"]},
-        {lv:"apiet", en:"to go around", tags:["prefix:ap"]},
-        {lv:"noiet", en:"to go down; walk distance", tags:["prefix:no"]},
-        {lv:"saiet", en:"to gather together", tags:["prefix:sa"]},
-        {lv:"paiet", en:"to pass (time), go by", tags:["prefix:pa"]}
-      ]
-    },
-    {
-      name: "Nākt ar priedēkļiem",
-      entries: [
-        {lv:"nākt", en:"to come (on foot)", tags:["base"]},
-        {lv:"ienākt", en:"to come in", tags:["prefix:ie"]},
-        {lv:"iznākt", en:"to come out", tags:["prefix:iz"]},
-        {lv:"atnākt", en:"to arrive, come here", tags:["prefix:at"]},
-        {lv:"aiznākt", en:"to come from afar", tags:["prefix:aiz"]},
-        {lv:"pienākt", en:"to approach; be due", tags:["prefix:pie"]},
-        {lv:"sanākt", en:"to gather; to turn out", tags:["prefix:sa"]},
-        {lv:"uznākt", en:"to come up (weather, emotions)", tags:["prefix:uz"]},
-        {lv:"nonākt", en:"to end up, to arrive at", tags:["prefix:no"]}
-      ]
-    },
-    {
-      name: "Kāpt ar priedēkļiem",
-      entries: [
-        {lv:"kāpt", en:"to climb, step", tags:["base"]},
-        {lv:"iekāpt", en:"to get in (vehicle)", tags:["prefix:ie"]},
-        {lv:"izkāpt", en:"to get out/off", tags:["prefix:iz"]},
-        {lv:"uzkāpt", en:"to climb up", tags:["prefix:uz"]},
-        {lv:"nokāpt", en:"to climb down", tags:["prefix:no"]},
-        {lv:"pārkāpt", en:"to step over; to violate", tags:["prefix:pār"]}
-      ]
-    },
-    {
-      name: "Lidot ar priedēkļiem",
-      entries: [
-        {lv:"lidot", en:"to fly", tags:["base"]},
-        {lv:"ielidot", en:"to fly in (arrive)", tags:["prefix:ie"]},
-        {lv:"izlidot", en:"to fly out (depart)", tags:["prefix:iz"]},
-        {lv:"atlidot", en:"to fly back", tags:["prefix:at"]},
-        {lv:"aizlidot", en:"to fly away", tags:["prefix:aiz"]},
-        {lv:"pārlidot", en:"to fly over", tags:["prefix:pār"]},
-        {lv:"aplidot", en:"to fly around", tags:["prefix:ap"]}
-      ]
-    },
-    {
-      name: "Nest ar priedēkļiem",
-      entries: [
-        {lv:"nest", en:"to carry (by hand)", tags:["base"]},
-        {lv:"ienest", en:"to carry in", tags:["prefix:ie"]},
-        {lv:"iznest", en:"to carry out", tags:["prefix:iz"]},
-        {lv:"aiznest", en:"to take away", tags:["prefix:aiz"]},
-        {lv:"atnest", en:"to bring (here)", tags:["prefix:at"]},
-        {lv:"pienest", en:"to bring to; serve", tags:["prefix:pie"]},
-        {lv:"pārnest", en:"to carry over / move", tags:["prefix:pār"]},
-        {lv:"uznest", en:"to carry up", tags:["prefix:uz"]},
-        {lv:"nonest", en:"to carry down", tags:["prefix:no"]},
-        {lv:"sanest", en:"to bring together (collect)", tags:["prefix:sa"]}
-      ]
-    },
-    {
-      name: "Refleksīvie un dzīves notikumi",
-      entries: [
-        {lv:"mainīties", en:"to change oneself, change state", tags:["reflexive"]},
-        {lv:"pārcelties", en:"to move, relocate", tags:["reflexive"]},
-        {lv:"atgriezties", en:"to return", tags:["reflexive"]},
-        {lv:"ciemoties", en:"to visit, be a guest", tags:["reflexive"]},
-        {lv:"viesoties", en:"to visit, be a guest", tags:["reflexive"]},
-        {lv:"precēties", en:"to marry", tags:["reflexive"]},
-        {lv:"apprecēties", en:"to get married", tags:["reflexive"]},
-        {lv:"piedzimt", en:"to be born"},
-        {lv:"celties", en:"to get up", tags:["reflexive"]},
-        {lv:"satikties", en:"to meet (each other)", tags:["reflexive"]},
-        {lv:"iemācīties", en:"to master, learn", tags:["reflexive"]}
-      ]
-    },
-    {
-      name: "B1 palīgdarbības vārdi",
-      entries: [
-        {lv:"apgūt", en:"to learn, acquire"},
-        {lv:"iegūt", en:"to obtain, gain"},
-        {lv:"kļūt", en:"to become"},
-        {lv:"tikt galā", en:"to manage, cope"},
-        {lv:"satikt", en:"to meet (someone)"},
-        {lv:"notikt", en:"to happen"},
-        {lv:"pietikt", en:"to be enough"},
-        {lv:"paveikt", en:"to accomplish"},
-        {lv:"pabeigt", en:"to finish"}
-      ]
-    }
-  ],
-  // Short mnemonic notes for each prefix (shown as hints in Forge)
-  notes: {
-    "prefix:iz": "iz- → ārā/rezultāts; completion/outward.",
-    "prefix:pār": "pār- → pāri/over; across; redo; sometimes 'too much'.",
-    "prefix:no": "no- → prom/away; removal; replacement.",
-    "prefix:sa": "sa- → kopā/together; gathering; sometimes 'a bit'.",
-    "prefix:ap": "ap- → ap/around; surround; exchange.",
-    "prefix:at": "at- → atpakaļ/back; towards.",
-    "prefix:aiz": "aiz- → prom/away; behind; to a limit.",
-    "prefix:ie": "ie- → iekšā/in; entering.",
-    "prefix:pie": "pie- → pie/at, towards.",
-    "prefix:uz": "uz- → uz/on, up; direction upward.",
-    "prefix:pa": "pa- → pa/along; a little; passing by; time passes."
-  },
-  // Prefix Forge deck: base + correct prefix + English clue
-  forge: [
-    {base:"mainīt", correct:"iz", en:"to alter; change completely (result)"},
-    {base:"mainīt", correct:"pār", en:"to transform; change over"},
-    {base:"mainīt", correct:"no", en:"to replace (change out)"},
-    {base:"mainīt", correct:"sa", en:"to swap/exchange (together)"},
-    {base:"mainīt", correct:"ap", en:"to exchange/switch (around)"},
-    
-    {base:"braukt", correct:"ie", en:"to drive in/enter"},
-    {base:"braukt", correct:"iz", en:"to drive out; leave"},
-    {base:"braukt", correct:"pie", en:"to drive up to"},
-    {base:"braukt", correct:"pār", en:"to drive over/across"},
-    {base:"braukt", correct:"ap", en:"to drive around"},
-    {base:"braukt", correct:"uz", en:"to drive up (onto)"},
-    {base:"braukt", correct:"no", en:"to drive down/off"},
-    {base:"braukt", correct:"at", en:"to arrive; come"},
-    {base:"braukt", correct:"aiz", en:"to leave; go away"},
-    {base:"braukt", correct:"sa", en:"to gather (arrive by vehicles)"},
-
-    {base:"iet", correct:"ie", en:"to go in, enter"},
-    {base:"iet", correct:"iz", en:"to go out, exit"},
-    {base:"iet", correct:"aiz", en:"to leave, go away"},
-    {base:"iet", correct:"at", en:"to depart (train, bus)"},
-    {base:"iet", correct:"pie", en:"to approach, go up to"},
-    {base:"iet", correct:"pār", en:"to cross, to switch"},
-    {base:"iet", correct:"ap", en:"to go around"},
-    {base:"iet", correct:"no", en:"to go down; walk distance"},
-    {base:"iet", correct:"sa", en:"to gather together"},
-    {base:"iet", correct:"pa", en:"to pass (time), go by"},
-
-    {base:"nākt", correct:"ie", en:"to come in"},
-    {base:"nākt", correct:"iz", en:"to come out"},
-    {base:"nākt", correct:"at", en:"to arrive, come here"},
-    {base:"nākt", correct:"aiz", en:"to come from afar"},
-    {base:"nākt", correct:"pie", en:"to approach; be due"},
-    {base:"nākt", correct:"sa", en:"to gather; to turn out"},
-    {base:"nākt", correct:"uz", en:"to come up (weather, emotions)"},
-    {base:"nākt", correct:"no", en:"to end up, to arrive at"},
-
-    {base:"kāpt", correct:"ie", en:"to get in (vehicle)"},
-    {base:"kāpt", correct:"iz", en:"to get out/off"},
-    {base:"kāpt", correct:"uz", en:"to climb up"},
-    {base:"kāpt", correct:"no", en:"to climb down"},
-    {base:"kāpt", correct:"pār", en:"to step over; to violate"},
-
-    {base:"lidot", correct:"ie", en:"to fly in (arrive)"},
-    {base:"lidot", correct:"iz", en:"to fly out (depart)"},
-    {base:"lidot", correct:"at", en:"to fly back"},
-    {base:"lidot", correct:"aiz", en:"to fly away"},
-    {base:"lidot", correct:"pār", en:"to fly over"},
-    {base:"lidot", correct:"ap", en:"to fly around"},
-
-    {base:"nest", correct:"ie", en:"to carry in"},
-    {base:"nest", correct:"iz", en:"to carry out"},
-    {base:"nest", correct:"aiz", en:"to take away"},
-    {base:"nest", correct:"at", en:"to bring (here)"},
-    {base:"nest", correct:"pie", en:"to bring to; serve"},
-    {base:"nest", correct:"pār", en:"to carry over / move"},
-    {base:"nest", correct:"uz", en:"to carry up"},
-    {base:"nest", correct:"no", en:"to carry down"},
-    {base:"nest", correct:"sa", en:"to bring together (collect)"}
-  ]
-};
+let DATA = null;
 
 /* =====================
    GLOBAL STATE & helpers
@@ -841,8 +636,27 @@ function initializeGame() {
 }
 
 // Initialize when DOM is ready and fonts are loaded
-function startInit() {
+async function loadVocabulary() {
+  try {
+    const res = await fetch('data/vocabulary.json');
+    if (!res.ok) throw new Error('Network response was not ok');
+    DATA = await res.json();
+  } catch (err) {
+    console.error('Failed to load vocabulary:', err);
+    loadingOverlay.textContent = 'Failed to load data';
+    setStatus('Failed to load data');
+    throw err;
+  }
+}
+
+async function startInit() {
   setupEventListeners();
+  try {
+    await loadVocabulary();
+  } catch (e) {
+    canvasElement.classList.remove('loading');
+    return;
+  }
   if (document.fonts && document.fonts.ready) {
     document.fonts.ready.then(() => {
       setTimeout(initializeGame, 50); // Small delay to ensure everything is ready

--- a/data/vocabulary.json
+++ b/data/vocabulary.json
@@ -1,0 +1,866 @@
+{
+  "units": [
+    {
+      "name": "Mainīt / Mainīties ģimene",
+      "entries": [
+        {
+          "lv": "mainīt",
+          "en": "to change (something)",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "mainīties",
+          "en": "to change (oneself)/change state",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "izmainīt",
+          "en": "to alter; to change completely",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "pārmainīt",
+          "en": "to transform; change over",
+          "tags": [
+            "prefix:pār"
+          ]
+        },
+        {
+          "lv": "nomainīt",
+          "en": "to replace; change out",
+          "tags": [
+            "prefix:no"
+          ]
+        },
+        {
+          "lv": "samainīt",
+          "en": "to swap; to exchange",
+          "tags": [
+            "prefix:sa"
+          ]
+        },
+        {
+          "lv": "apmainīt",
+          "en": "to exchange; to switch",
+          "tags": [
+            "prefix:ap"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Braukt ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "braukt",
+          "en": "to go (by transport)",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "atbraukt",
+          "en": "to arrive (come)",
+          "tags": [
+            "prefix:at"
+          ]
+        },
+        {
+          "lv": "aizbraukt",
+          "en": "to leave, go away",
+          "tags": [
+            "prefix:aiz"
+          ]
+        },
+        {
+          "lv": "iebraukt",
+          "en": "to enter (drive into)",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "izbraukt",
+          "en": "to go out (drive out)",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "piebraukt",
+          "en": "to drive up to",
+          "tags": [
+            "prefix:pie"
+          ]
+        },
+        {
+          "lv": "apbraukt",
+          "en": "to drive around",
+          "tags": [
+            "prefix:ap"
+          ]
+        },
+        {
+          "lv": "pārbraukt",
+          "en": "to drive over / across",
+          "tags": [
+            "prefix:pār"
+          ]
+        },
+        {
+          "lv": "nobraukt",
+          "en": "to drive down / run over",
+          "tags": [
+            "prefix:no"
+          ]
+        },
+        {
+          "lv": "uzbraukt",
+          "en": "to drive up (onto)",
+          "tags": [
+            "prefix:uz"
+          ]
+        },
+        {
+          "lv": "sabraukt",
+          "en": "to gather (arrive by vehicles)",
+          "tags": [
+            "prefix:sa"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Iet ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "iet",
+          "en": "to go (on foot)",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "ieiet",
+          "en": "to go in, enter",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "iziet",
+          "en": "to go out, exit",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "aiziet",
+          "en": "to leave, go away",
+          "tags": [
+            "prefix:aiz"
+          ]
+        },
+        {
+          "lv": "atiet",
+          "en": "to depart (train, bus)",
+          "tags": [
+            "prefix:at"
+          ]
+        },
+        {
+          "lv": "pieiet",
+          "en": "to approach, go up to",
+          "tags": [
+            "prefix:pie"
+          ]
+        },
+        {
+          "lv": "pāriet",
+          "en": "to cross, to switch",
+          "tags": [
+            "prefix:pār"
+          ]
+        },
+        {
+          "lv": "apiet",
+          "en": "to go around",
+          "tags": [
+            "prefix:ap"
+          ]
+        },
+        {
+          "lv": "noiet",
+          "en": "to go down; walk distance",
+          "tags": [
+            "prefix:no"
+          ]
+        },
+        {
+          "lv": "saiet",
+          "en": "to gather together",
+          "tags": [
+            "prefix:sa"
+          ]
+        },
+        {
+          "lv": "paiet",
+          "en": "to pass (time), go by",
+          "tags": [
+            "prefix:pa"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Nākt ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "nākt",
+          "en": "to come (on foot)",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "ienākt",
+          "en": "to come in",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "iznākt",
+          "en": "to come out",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "atnākt",
+          "en": "to arrive, come here",
+          "tags": [
+            "prefix:at"
+          ]
+        },
+        {
+          "lv": "aiznākt",
+          "en": "to come from afar",
+          "tags": [
+            "prefix:aiz"
+          ]
+        },
+        {
+          "lv": "pienākt",
+          "en": "to approach; be due",
+          "tags": [
+            "prefix:pie"
+          ]
+        },
+        {
+          "lv": "sanākt",
+          "en": "to gather; to turn out",
+          "tags": [
+            "prefix:sa"
+          ]
+        },
+        {
+          "lv": "uznākt",
+          "en": "to come up (weather, emotions)",
+          "tags": [
+            "prefix:uz"
+          ]
+        },
+        {
+          "lv": "nonākt",
+          "en": "to end up, to arrive at",
+          "tags": [
+            "prefix:no"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Kāpt ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "kāpt",
+          "en": "to climb, step",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "iekāpt",
+          "en": "to get in (vehicle)",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "izkāpt",
+          "en": "to get out/off",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "uzkāpt",
+          "en": "to climb up",
+          "tags": [
+            "prefix:uz"
+          ]
+        },
+        {
+          "lv": "nokāpt",
+          "en": "to climb down",
+          "tags": [
+            "prefix:no"
+          ]
+        },
+        {
+          "lv": "pārkāpt",
+          "en": "to step over; to violate",
+          "tags": [
+            "prefix:pār"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Lidot ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "lidot",
+          "en": "to fly",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "ielidot",
+          "en": "to fly in (arrive)",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "izlidot",
+          "en": "to fly out (depart)",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "atlidot",
+          "en": "to fly back",
+          "tags": [
+            "prefix:at"
+          ]
+        },
+        {
+          "lv": "aizlidot",
+          "en": "to fly away",
+          "tags": [
+            "prefix:aiz"
+          ]
+        },
+        {
+          "lv": "pārlidot",
+          "en": "to fly over",
+          "tags": [
+            "prefix:pār"
+          ]
+        },
+        {
+          "lv": "aplidot",
+          "en": "to fly around",
+          "tags": [
+            "prefix:ap"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Nest ar priedēkļiem",
+      "entries": [
+        {
+          "lv": "nest",
+          "en": "to carry (by hand)",
+          "tags": [
+            "base"
+          ]
+        },
+        {
+          "lv": "ienest",
+          "en": "to carry in",
+          "tags": [
+            "prefix:ie"
+          ]
+        },
+        {
+          "lv": "iznest",
+          "en": "to carry out",
+          "tags": [
+            "prefix:iz"
+          ]
+        },
+        {
+          "lv": "aiznest",
+          "en": "to take away",
+          "tags": [
+            "prefix:aiz"
+          ]
+        },
+        {
+          "lv": "atnest",
+          "en": "to bring (here)",
+          "tags": [
+            "prefix:at"
+          ]
+        },
+        {
+          "lv": "pienest",
+          "en": "to bring to; serve",
+          "tags": [
+            "prefix:pie"
+          ]
+        },
+        {
+          "lv": "pārnest",
+          "en": "to carry over / move",
+          "tags": [
+            "prefix:pār"
+          ]
+        },
+        {
+          "lv": "uznest",
+          "en": "to carry up",
+          "tags": [
+            "prefix:uz"
+          ]
+        },
+        {
+          "lv": "nonest",
+          "en": "to carry down",
+          "tags": [
+            "prefix:no"
+          ]
+        },
+        {
+          "lv": "sanest",
+          "en": "to bring together (collect)",
+          "tags": [
+            "prefix:sa"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Refleksīvie un dzīves notikumi",
+      "entries": [
+        {
+          "lv": "mainīties",
+          "en": "to change oneself, change state",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "pārcelties",
+          "en": "to move, relocate",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "atgriezties",
+          "en": "to return",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "ciemoties",
+          "en": "to visit, be a guest",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "viesoties",
+          "en": "to visit, be a guest",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "precēties",
+          "en": "to marry",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "apprecēties",
+          "en": "to get married",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "piedzimt",
+          "en": "to be born"
+        },
+        {
+          "lv": "celties",
+          "en": "to get up",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "satikties",
+          "en": "to meet (each other)",
+          "tags": [
+            "reflexive"
+          ]
+        },
+        {
+          "lv": "iemācīties",
+          "en": "to master, learn",
+          "tags": [
+            "reflexive"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "B1 palīgdarbības vārdi",
+      "entries": [
+        {
+          "lv": "apgūt",
+          "en": "to learn, acquire"
+        },
+        {
+          "lv": "iegūt",
+          "en": "to obtain, gain"
+        },
+        {
+          "lv": "kļūt",
+          "en": "to become"
+        },
+        {
+          "lv": "tikt galā",
+          "en": "to manage, cope"
+        },
+        {
+          "lv": "satikt",
+          "en": "to meet (someone)"
+        },
+        {
+          "lv": "notikt",
+          "en": "to happen"
+        },
+        {
+          "lv": "pietikt",
+          "en": "to be enough"
+        },
+        {
+          "lv": "paveikt",
+          "en": "to accomplish"
+        },
+        {
+          "lv": "pabeigt",
+          "en": "to finish"
+        }
+      ]
+    }
+  ],
+  "notes": {
+    "prefix:iz": "iz- → ārā/rezultāts; completion/outward.",
+    "prefix:pār": "pār- → pāri/over; across; redo; sometimes 'too much'.",
+    "prefix:no": "no- → prom/away; removal; replacement.",
+    "prefix:sa": "sa- → kopā/together; gathering; sometimes 'a bit'.",
+    "prefix:ap": "ap- → ap/around; surround; exchange.",
+    "prefix:at": "at- → atpakaļ/back; towards.",
+    "prefix:aiz": "aiz- → prom/away; behind; to a limit.",
+    "prefix:ie": "ie- → iekšā/in; entering.",
+    "prefix:pie": "pie- → pie/at, towards.",
+    "prefix:uz": "uz- → uz/on, up; direction upward.",
+    "prefix:pa": "pa- → pa/along; a little; passing by; time passes."
+  },
+  "forge": [
+    {
+      "base": "mainīt",
+      "correct": "iz",
+      "en": "to alter; change completely (result)"
+    },
+    {
+      "base": "mainīt",
+      "correct": "pār",
+      "en": "to transform; change over"
+    },
+    {
+      "base": "mainīt",
+      "correct": "no",
+      "en": "to replace (change out)"
+    },
+    {
+      "base": "mainīt",
+      "correct": "sa",
+      "en": "to swap/exchange (together)"
+    },
+    {
+      "base": "mainīt",
+      "correct": "ap",
+      "en": "to exchange/switch (around)"
+    },
+    {
+      "base": "braukt",
+      "correct": "ie",
+      "en": "to drive in/enter"
+    },
+    {
+      "base": "braukt",
+      "correct": "iz",
+      "en": "to drive out; leave"
+    },
+    {
+      "base": "braukt",
+      "correct": "pie",
+      "en": "to drive up to"
+    },
+    {
+      "base": "braukt",
+      "correct": "pār",
+      "en": "to drive over/across"
+    },
+    {
+      "base": "braukt",
+      "correct": "ap",
+      "en": "to drive around"
+    },
+    {
+      "base": "braukt",
+      "correct": "uz",
+      "en": "to drive up (onto)"
+    },
+    {
+      "base": "braukt",
+      "correct": "no",
+      "en": "to drive down/off"
+    },
+    {
+      "base": "braukt",
+      "correct": "at",
+      "en": "to arrive; come"
+    },
+    {
+      "base": "braukt",
+      "correct": "aiz",
+      "en": "to leave; go away"
+    },
+    {
+      "base": "braukt",
+      "correct": "sa",
+      "en": "to gather (arrive by vehicles)"
+    },
+    {
+      "base": "iet",
+      "correct": "ie",
+      "en": "to go in, enter"
+    },
+    {
+      "base": "iet",
+      "correct": "iz",
+      "en": "to go out, exit"
+    },
+    {
+      "base": "iet",
+      "correct": "aiz",
+      "en": "to leave, go away"
+    },
+    {
+      "base": "iet",
+      "correct": "at",
+      "en": "to depart (train, bus)"
+    },
+    {
+      "base": "iet",
+      "correct": "pie",
+      "en": "to approach, go up to"
+    },
+    {
+      "base": "iet",
+      "correct": "pār",
+      "en": "to cross, to switch"
+    },
+    {
+      "base": "iet",
+      "correct": "ap",
+      "en": "to go around"
+    },
+    {
+      "base": "iet",
+      "correct": "no",
+      "en": "to go down; walk distance"
+    },
+    {
+      "base": "iet",
+      "correct": "sa",
+      "en": "to gather together"
+    },
+    {
+      "base": "iet",
+      "correct": "pa",
+      "en": "to pass (time), go by"
+    },
+    {
+      "base": "nākt",
+      "correct": "ie",
+      "en": "to come in"
+    },
+    {
+      "base": "nākt",
+      "correct": "iz",
+      "en": "to come out"
+    },
+    {
+      "base": "nākt",
+      "correct": "at",
+      "en": "to arrive, come here"
+    },
+    {
+      "base": "nākt",
+      "correct": "aiz",
+      "en": "to come from afar"
+    },
+    {
+      "base": "nākt",
+      "correct": "pie",
+      "en": "to approach; be due"
+    },
+    {
+      "base": "nākt",
+      "correct": "sa",
+      "en": "to gather; to turn out"
+    },
+    {
+      "base": "nākt",
+      "correct": "uz",
+      "en": "to come up (weather, emotions)"
+    },
+    {
+      "base": "nākt",
+      "correct": "no",
+      "en": "to end up, to arrive at"
+    },
+    {
+      "base": "kāpt",
+      "correct": "ie",
+      "en": "to get in (vehicle)"
+    },
+    {
+      "base": "kāpt",
+      "correct": "iz",
+      "en": "to get out/off"
+    },
+    {
+      "base": "kāpt",
+      "correct": "uz",
+      "en": "to climb up"
+    },
+    {
+      "base": "kāpt",
+      "correct": "no",
+      "en": "to climb down"
+    },
+    {
+      "base": "kāpt",
+      "correct": "pār",
+      "en": "to step over; to violate"
+    },
+    {
+      "base": "lidot",
+      "correct": "ie",
+      "en": "to fly in (arrive)"
+    },
+    {
+      "base": "lidot",
+      "correct": "iz",
+      "en": "to fly out (depart)"
+    },
+    {
+      "base": "lidot",
+      "correct": "at",
+      "en": "to fly back"
+    },
+    {
+      "base": "lidot",
+      "correct": "aiz",
+      "en": "to fly away"
+    },
+    {
+      "base": "lidot",
+      "correct": "pār",
+      "en": "to fly over"
+    },
+    {
+      "base": "lidot",
+      "correct": "ap",
+      "en": "to fly around"
+    },
+    {
+      "base": "nest",
+      "correct": "ie",
+      "en": "to carry in"
+    },
+    {
+      "base": "nest",
+      "correct": "iz",
+      "en": "to carry out"
+    },
+    {
+      "base": "nest",
+      "correct": "aiz",
+      "en": "to take away"
+    },
+    {
+      "base": "nest",
+      "correct": "at",
+      "en": "to bring (here)"
+    },
+    {
+      "base": "nest",
+      "correct": "pie",
+      "en": "to bring to; serve"
+    },
+    {
+      "base": "nest",
+      "correct": "pār",
+      "en": "to carry over / move"
+    },
+    {
+      "base": "nest",
+      "correct": "uz",
+      "en": "to carry up"
+    },
+    {
+      "base": "nest",
+      "correct": "no",
+      "en": "to carry down"
+    },
+    {
+      "base": "nest",
+      "correct": "sa",
+      "en": "to bring together (collect)"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Move vocabulary dataset into `data/vocabulary.json`
- Fetch and parse vocabulary JSON during app initialization
- Show message if vocabulary fails to load

## Testing
- `node --check app.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bbeb6139d083209215c00448d83214