### PR TITLE
Add basic i18n with language selector

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,51 @@
+{
+  "html": { "title": "B1 LV→EN: Match Rush + Prefix Forge" },
+  "badge": "Week 1",
+  "gameTitle": "LV→EN Word Games (B1)",
+  "buttons": {
+    "modeMatch": "\u25B6 Match Rush",
+    "modeForge": "\u25B6 Prefix Forge",
+    "practice": "Practice",
+    "challenge": "Challenge",
+    "prevAria": "Previous card",
+    "nextAria": "Next card",
+    "deckSizeAria": "Toggle deck size",
+    "deckSizeTitle": "Toggle deck size",
+    "export": "Export Results (CSV)",
+    "exportAria": "Export results as CSV",
+    "help": "Help",
+    "helpAria": "Help"
+  },
+  "labels": {
+    "loading": "Loading...",
+    "legend": "<b>Controls:</b> Mouse clicks. — <span class=\"kbd\">H</span> help, <span class=\"kbd\">R</span> restart round, <span class=\"kbd\">1</span> Match, <span class=\"kbd\">2</span> Forge, <span class=\"kbd\">D</span> deck size. <br/>📏 = Fit screen (no scroll), 📜 = Full deck (scroll if needed). LV→EN only."
+  },
+  "status": {
+    "ready": "Ready. Choose a mode.",
+    "practice": "Practice mode",
+    "challenge": "Challenge mode (Match = ♥♥♥)",
+    "fit": "Fit to screen mode",
+    "full": "Full deck mode (scrollable)"
+  },
+  "deckSize": {
+    "titleAuto": "Switch to full deck (scrollable)",
+    "titleFull": "Switch to fit screen (no scroll)"
+  },
+  "help": {
+    "title": "Help",
+    "close": "Close",
+    "lines": [
+      "\u25B6 MATCH RUSH — Click the pair: first LV word, then its EN meaning.",
+      "Mistakes in practice show a brief hint (e.g., -ties = reflexive).",
+      "Challenge mode has a timer and hearts.",
+      "",
+      "📏 Deck Size — Toggle between 'fit screen' (no scrolling)",
+      "and 'full deck' (scroll, more words).",
+      "",
+      "\u25B6 PREFIX FORGE — Add the correct prefix to the verb root",
+      "(e.g., __mainīt → izmainīt) based on the given EN meaning.",
+      "",
+      "Shortcuts: [1] Match, [2] Forge, [H] help, [R] restart, [D] deck size."
+    ]
+  }
+}

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -1,0 +1,51 @@
+{
+  "html": { "title": "B1 LV→EN: Match Rush + Prefix Forge" },
+  "badge": "Week 1",
+  "gameTitle": "LV→EN Vārdu Spēles (B1)",
+  "buttons": {
+    "modeMatch": "\u25B6 Match Rush",
+    "modeForge": "\u25B6 Prefix Forge",
+    "practice": "Praktizēties",
+    "challenge": "Izaicinājums",
+    "prevAria": "Iepriekšējā kartīte",
+    "nextAria": "Nākamā kartīte",
+    "deckSizeAria": "Pārslēgt kavas izmēru",
+    "deckSizeTitle": "Pārslēgt kavas izmēru",
+    "export": "Eksportēt rezultātus (CSV)",
+    "exportAria": "Eksportēt rezultātus CSV formātā",
+    "help": "Palīdzība",
+    "helpAria": "Palīdzība"
+  },
+  "labels": {
+    "loading": "Ielādē...",
+    "legend": "<b>Vadība:</b> Pelē klikšķi. — <span class=\"kbd\">H</span> palīdzība, <span class=\"kbd\">R</span> atsākt raundu, <span class=\"kbd\">1</span> Match, <span class=\"kbd\">2</span> Forge, <span class=\"kbd\">D</span> kavas izmērs. <br/>📏 = Pielāgot ekrānam (bez ritināšanas), 📜 = Pilna kava (ar ritināšanu). LV→EN only."
+  },
+  "status": {
+    "ready": "Gatavs. Izvēlies režīmu.",
+    "practice": "Practice režīms",
+    "challenge": "Challenge režīms (Match = ♥♥♥)",
+    "fit": "Fit to screen mode",
+    "full": "Full deck mode (scrollable)"
+  },
+  "deckSize": {
+    "titleAuto": "Switch to full deck (scrollable)",
+    "titleFull": "Switch to fit screen (no scroll)"
+  },
+  "help": {
+    "title": "Palīdzība",
+    "close": "Aizvērt",
+    "lines": [
+      "\u25B6 MATCH RUSH — Klikšķini pāri: vispirms LV vārds, tad tā EN nozīme.",
+      "Kļūdas praksē rāda īsu skaidrojumu (piem., -ties = refleksīvs).",
+      "Challenge režīmā ir taimeris un sirdis.",
+      "",
+      "📏 Deck Size — Pārslēdz starp 'fit screen' (bez ritināšanas)",
+      "un 'full deck' (ar ritināšanu, vairāk vārdu).",
+      "",
+      "\u25B6 PREFIX FORGE — Pievieno pareizo priedēkli pie verbu saknes",
+      "(piem., __mainīt → izmainīt) pēc dotās EN nozīmes.",
+      "",
+      "Īsceļi: [1] Match, [2] Forge, [H] help, [R] restart, [D] deck size."
+    ]
+  }
+}

--- a/index.html
+++ b/index.html
@@ -6,37 +6,38 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 <meta name="format-detection" content="telephone=no" />
-<title>B1 LV→EN: Match Rush + Prefix Forge</title>
+<title></title>
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <div id="wrap">
-  <!-- New header badge -->
-  <div id="header"><span class="week-badge">Week 1</span></div>
+  <div id="header">
+    <span class="week-badge"></span>
+    <select id="language-select">
+      <option value="lv">Latviešu</option>
+      <option value="en">English</option>
+    </select>
+  </div>
 
-  <h1>LV→EN Vārdu Spēles (B1)</h1>
+  <h1 id="title"></h1>
   <div id="ui">
-    <button id="mode-match" class="pill">▶ Match Rush</button>
-    <button id="mode-forge" class="pill">▶ Prefix Forge</button>
-    <button id="btn-practice" class="ghost" aria-label="Praktizēties">Practice</button>
-    <button id="btn-challenge" class="ghost" aria-label="Izaicinājums">Challenge</button>
-    <button id="btn-prev" class="outline small" aria-label="Iepriekšējā kartīte">⟨</button>
-    <button id="btn-next" class="outline small" aria-label="Nākamā kartīte">⟩</button>
-    <button id="btn-deck-size" class="outline small" title="Pārslēgt kavas izmēru" aria-label="Pārslēgt kavas izmēru">📏</button>
-    <button id="btn-export" class="ok" aria-label="Eksportēt rezultātus CSV formātā">Export Results (CSV)</button>
-    <button id="btn-help" class="ghost" aria-label="Palīdzība">Help</button>
+    <button id="mode-match" class="pill"></button>
+    <button id="mode-forge" class="pill"></button>
+    <button id="btn-practice" class="ghost"></button>
+    <button id="btn-challenge" class="ghost"></button>
+    <button id="btn-prev" class="outline small">⟨</button>
+    <button id="btn-next" class="outline small">⟩</button>
+    <button id="btn-deck-size" class="outline small">📏</button>
+    <button id="btn-export" class="ok"></button>
+    <button id="btn-help" class="ghost"></button>
     <span id="status" style="margin-left:auto;font-weight:700;"></span>
   </div>
 
-  <!-- All interactive UI is drawn on this canvas via 2D context -->
   <div class="canvas-container">
     <canvas id="canvas" width="980" height="560"></canvas>
-    <div class="loading-overlay" id="loading">Loading...</div>
+    <div class="loading-overlay" id="loading"></div>
   </div>
-  <div id="legend">
-    <b>Controls:</b> Mouse clicks. — <span class="kbd">H</span> help, <span class="kbd">R</span> restart round, <span class="kbd">1</span> Match, <span class="kbd">2</span> Forge, <span class="kbd">D</span> deck size. <br/>
-    📏 = Fit screen (no scroll), 📜 = Full deck (scroll if needed). LV→EN only.
-  </div>
+  <div id="legend"></div>
 </div>
 
 <script type="module" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,51 @@
 import { canvas, updateCanvasScale, getCanvasCoordinates, renderConfetti, roundedRect, drawText, W, H, scale } from './src/render.js';
-import { state, MODES, setStatus, hitAt, resetClicks, clickables, setRedraw, HELP_TEXT, triggerRedraw } from './src/state.js';
+import { state, MODES, setStatus, hitAt, resetClicks, clickables, setRedraw, HELP_TEXT, setHelpText, triggerRedraw } from './src/state.js';
 import { startMatchRound, drawMatch } from './src/match.js';
 import { startForgeRound, drawForge } from './src/forge.js';
+
+let i18n = {};
+let currentLang = 'lv';
+
+async function loadTranslations(lang){
+  const res = await fetch(`i18n/${lang}.json`);
+  i18n = await res.json();
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  applyTranslations();
+}
+
+function applyTranslations(){
+  document.title = i18n.html.title;
+  document.querySelector('.week-badge').textContent = i18n.badge;
+  document.getElementById('title').textContent = i18n.gameTitle;
+  const btnMatch = document.getElementById('mode-match');
+  btnMatch.textContent = i18n.buttons.modeMatch;
+  const btnForge = document.getElementById('mode-forge');
+  btnForge.textContent = i18n.buttons.modeForge;
+  const btnPractice = document.getElementById('btn-practice');
+  btnPractice.textContent = i18n.buttons.practice;
+  btnPractice.setAttribute('aria-label', i18n.buttons.practice);
+  const btnChallenge = document.getElementById('btn-challenge');
+  btnChallenge.textContent = i18n.buttons.challenge;
+  btnChallenge.setAttribute('aria-label', i18n.buttons.challenge);
+  document.getElementById('btn-prev').setAttribute('aria-label', i18n.buttons.prevAria);
+  document.getElementById('btn-next').setAttribute('aria-label', i18n.buttons.nextAria);
+  const deckBtn = document.getElementById('btn-deck-size');
+  deckBtn.setAttribute('aria-label', i18n.buttons.deckSizeAria);
+  deckBtn.title = state.deckSizeMode === 'auto' ? i18n.deckSize.titleAuto : i18n.deckSize.titleFull;
+  const btnExport = document.getElementById('btn-export');
+  btnExport.textContent = i18n.buttons.export;
+  btnExport.setAttribute('aria-label', i18n.buttons.exportAria);
+  const btnHelp = document.getElementById('btn-help');
+  btnHelp.textContent = i18n.buttons.help;
+  btnHelp.setAttribute('aria-label', i18n.buttons.helpAria);
+  document.getElementById('loading').textContent = i18n.labels.loading;
+  document.getElementById('legend').innerHTML = i18n.labels.legend;
+  document.getElementById('language-select').value = currentLang;
+  setStatus(i18n.status.ready);
+  setHelpText(i18n.help.lines.join('\n'));
+  triggerRedraw();
+}
 
 function drawHelp(){
   const isMobile = scale < 0.7;
@@ -11,7 +55,7 @@ function drawHelp(){
   const x = W/2 - w/2;
   const y = H/2 - h/2;
   roundedRect(x,y,w,h,14,'#151821','#3a4252');
-  drawText("Palīdzība", x+pad, y+28, {font:'bold 18px system-ui', color:'#9dd4ff'});
+  drawText(i18n.help.title, x+pad, y+28, {font:'bold 18px system-ui', color:'#9dd4ff'});
   const helpLines = HELP_TEXT.split('\n');
   const fontSize = isMobile ? 12 : 14;
   const lineHeight = isMobile ? 16 : 20;
@@ -26,7 +70,7 @@ function drawHelp(){
   const bx = x + w - bw - 16;
   const by = y + h - bh - 14;
   roundedRect(bx,by,bw,bh,10,'#334','#556');
-  drawText("Aizvērt", bx + (isMobile ? 8 : 12), by + (isMobile ? 22 : 20), {font:`${isMobile ? 12 : 14}px system-ui`});
+  drawText(i18n.help.close, bx + (isMobile ? 8 : 12), by + (isMobile ? 22 : 20), {font:`${isMobile ? 12 : 14}px system-ui`});
   clickables.push({x:bx,y:by,w:bw,h:bh,onClick:()=>{ state.showHelp=false; triggerRedraw(); }});
 }
 
@@ -40,20 +84,21 @@ setRedraw(draw);
 function setupEventListeners(){
   document.getElementById('mode-match').addEventListener('click', ()=>{ state.mode=MODES.MATCH; state.roundIndex=0; startMatchRound(); });
   document.getElementById('mode-forge').addEventListener('click', ()=>{ state.mode=MODES.FORGE; state.roundIndex=0; startForgeRound(); });
-  document.getElementById('btn-practice').addEventListener('click', ()=>{ state.difficulty='practice'; setStatus("Practice režīms"); });
-  document.getElementById('btn-challenge').addEventListener('click', ()=>{ state.difficulty='challenge'; setStatus("Challenge režīms (Match = ♥♥♥)"); });
+  document.getElementById('btn-practice').addEventListener('click', ()=>{ state.difficulty='practice'; setStatus(i18n.status.practice); });
+  document.getElementById('btn-challenge').addEventListener('click', ()=>{ state.difficulty='challenge'; setStatus(i18n.status.challenge); });
   document.getElementById('btn-prev').addEventListener('click', ()=>{ state.roundIndex=Math.max(0,state.roundIndex-1); state.mode===MODES.MATCH?startMatchRound():startForgeRound(); });
   document.getElementById('btn-next').addEventListener('click', ()=>{ state.roundIndex++; state.mode===MODES.MATCH?startMatchRound():startForgeRound(); });
   document.getElementById('btn-deck-size').addEventListener('click', ()=>{
     state.deckSizeMode = state.deckSizeMode === 'auto' ? 'full' : 'auto';
     const btn = document.getElementById('btn-deck-size');
     btn.textContent = state.deckSizeMode === 'auto' ? '📏' : '📜';
-    btn.title = state.deckSizeMode === 'auto' ? 'Switch to full deck (scrollable)' : 'Switch to fit screen (no scroll)';
-    setStatus(state.deckSizeMode === 'auto' ? 'Fit to screen mode' : 'Full deck mode (scrollable)');
+    btn.title = state.deckSizeMode === 'auto' ? i18n.deckSize.titleAuto : i18n.deckSize.titleFull;
+    setStatus(state.deckSizeMode === 'auto' ? i18n.status.fit : i18n.status.full);
     if(state.mode === MODES.MATCH) startMatchRound();
   });
   document.getElementById('btn-help').addEventListener('click', ()=>{ state.showHelp=!state.showHelp; triggerRedraw(); });
   document.getElementById('btn-export').addEventListener('click', exportCSV);
+  document.getElementById('language-select').addEventListener('change', e=>{ loadTranslations(e.target.value); });
   canvas.addEventListener('mousemove', e=>{
     const coords = getCanvasCoordinates(e.clientX, e.clientY);
     canvas.style.cursor = hitAt(coords.x, coords.y) ? 'pointer' : 'default';
@@ -87,7 +132,8 @@ function setupEventListeners(){
       state.deckSizeMode = state.deckSizeMode === 'auto' ? 'full' : 'auto';
       const btn = document.getElementById('btn-deck-size');
       btn.textContent = state.deckSizeMode === 'auto' ? '📏' : '📜';
-      setStatus(state.deckSizeMode === 'auto' ? 'Fit to screen mode' : 'Full deck mode (scrollable)');
+      btn.title = state.deckSizeMode === 'auto' ? i18n.deckSize.titleAuto : i18n.deckSize.titleFull;
+      setStatus(state.deckSizeMode === 'auto' ? i18n.status.fit : i18n.status.full);
       if(state.mode===MODES.MATCH) startMatchRound();
     }
   });
@@ -101,7 +147,6 @@ function exportCSV(){
   const a = document.createElement('a'); a.href=url; a.download="b1_game_results.csv"; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
 }
 
-setStatus("Gatavs. Izvēlies režīmu.");
 const loadingOverlay = document.getElementById('loading');
 const canvasElement = canvas;
 loadingOverlay.classList.add('visible');
@@ -121,6 +166,7 @@ async function loadVocabulary(){
 }
 
 async function startInit(){
+  await loadTranslations(currentLang);
   setupEventListeners();
   try { await loadVocabulary(); } catch(e){ canvasElement.classList.remove('loading'); return; }
   if (document.fonts && document.fonts.ready) {

--- a/src/state.js
+++ b/src/state.js
@@ -22,19 +22,8 @@ export const state = {
 export function shuffle(arr){ for(let i=arr.length-1;i>0;i--){ const j=(state.rng()*(i+1))|0; [arr[i],arr[j]]=[arr[j],arr[i]] } return arr; }
 export function choice(arr){ return arr[(state.rng()*arr.length)|0]; }
 export function now(){ return performance.now(); }
-export const HELP_TEXT = [
-  "▶ MATCH RUSH — Klikšķini pāri: vispirms LV vārds, tad tā EN nozīme.",
-  "Kļūdas praksē rāda īsu skaidrojumu (piem., -ties = refleksīvs).",
-  "Challenge režīmā ir taimeris un sirdis.",
-  "",
-  "📏 Deck Size — Pārslēdz starp 'fit screen' (bez ritināšanas)",
-  "un 'full deck' (ar ritināšanu, vairāk vārdu).",
-  "",
-  "▶ PREFIX FORGE — Pievieno pareizo priedēkli pie verbu saknes",
-  "(piem., __mainīt → izmainīt) pēc dotās EN nozīmes.",
-  "",
-  "Īsceļi: [1] Match, [2] Forge, [H] help, [R] restart, [D] deck size."
-].join("\n");
+export let HELP_TEXT = '';
+export function setHelpText(t){ HELP_TEXT = t; }
 export function setStatus(s){ document.getElementById('status').textContent = s || ''; }
 export let clickables = [];
 export function hitAt(x,y){ for(const c of clickables){ if(x>=c.x && x<=c.x+c.w && y>=c.y && y<=c.y+c.h) return c; } return null; }


### PR DESCRIPTION
## Summary
- add `i18n` directory with English and Latvian JSON translations
- replace hard-coded strings with lookup-based translations and update buttons/help
- add language selector to switch page `lang` and reload translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d2e26bc8320aeeacdcbb0043dea