### PR TITLE
Improve vocabulary load error handling and offline caching

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,14 @@ async function loadVocabulary(from='lv', to='en'){
 async function startInit(){
   await loadTranslations(currentLang);
   setupEventListeners();
-  try { await loadVocabulary('lv','en'); } catch(e){ canvasElement.classList.remove('loading'); return; }
+  try {
+    await loadVocabulary('lv','en');
+  } catch(e){
+    console.error('Failed to load vocabulary', e);
+    loadingOverlay.textContent = i18n.labels?.loadError || 'Failed to load data';
+    canvasElement.classList.remove('loading');
+    return;
+  }
   if (document.fonts && document.fonts.ready) {
     document.fonts.ready.then(()=>{ setTimeout(initializeGame,50); });
   } else {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
   },
   "labels": {
     "loading": "Loading...",
+    "loadError": "Failed to load data.",
     "legend": "<b>Controls:</b> Mouse clicks. — <span class=\"kbd\">H</span> help, <span class=\"kbd\">R</span> restart round, <span class=\"kbd\">1</span> Match, <span class=\"kbd\">2</span> Forge, <span class=\"kbd\">D</span> deck size. <br/>📏 = Fit screen (no scroll), 📜 = Full deck (scroll if needed). LV→EN only.",
     "languageSelect": "Choose language",
     "controls": "Game controls",

--- a/i18n/lv.json
+++ b/i18n/lv.json
@@ -18,6 +18,7 @@
   },
   "labels": {
     "loading": "Ielādē...",
+    "loadError": "Neizdevās ielādēt datus.",
     "legend": "<b>Vadība:</b> Pelē klikšķi. — <span class=\"kbd\">H</span> palīdzība, <span class=\"kbd\">R</span> atsākt raundu, <span class=\"kbd\">1</span> Match, <span class=\"kbd\">2</span> Forge, <span class=\"kbd\">D</span> kavas izmērs. <br/>📏 = Pielāgot ekrānam (bez ritināšanas), 📜 = Pilna kava (ar ritināšanu). LV→EN only.",
     "languageSelect": "Izvēlies valodu",
     "controls": "Spēles vadības",

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,14 @@
-const CACHE_NAME = 'latvian-lang-b1-v1';
+const CACHE_NAME = 'latvian-lang-b1-v2';
 const ASSETS = [
   '/',
   '/index.html',
   '/app.js',
+  '/src/render.js',
+  '/src/state.js',
+  '/src/match.js',
+  '/src/forge.js',
+  '/i18n/en.json',
+  '/i18n/lv.json',
   '/styles.css',
   '/data/lv-en/forge.json',
   '/data/lv-en/units.json',


### PR DESCRIPTION
## Summary
- Show a translated error message when vocabulary data fails to load
- Add `loadError` i18n entries for Latvian and English
- Update service worker cache to include modules and translation files

## Testing
- `node --check app.js`
- `node --check sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbf354539883208763e541aa478bcd