### PR TITLE
fix: avoid draw before game state exists

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,11 @@ function drawHelp(){
 }
 
 function draw(){
-  if(state.mode===MODES.MATCH) drawMatch(); else drawForge();
+  if(state.mode===MODES.MATCH){
+    if(state.matchState) drawMatch();
+  } else {
+    if(state.forgeState) drawForge();
+  }
   if(renderConfetti()) requestAnimationFrame(draw);
   if(state.showHelp) drawHelp();
 }


### PR DESCRIPTION
## Summary
- prevent draw() from running before match or forge state is initialized so loading overlay clears

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a5256b08320bc9b56d591e224e7