### PR TITLE
Fix loading screen hang due to unresolved fonts promise

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,10 +189,24 @@ async function startInit(){
     canvasElement.classList.remove('loading');
     return;
   }
+  const startGame = () => {
+    try {
+      initializeGame();
+    } catch (err) {
+      console.error('Initialization error', err);
+      loadingOverlay.textContent = i18n.labels?.loadError || 'Failed to load data';
+      canvasElement.classList.remove('loading');
+    }
+  };
+
   if (document.fonts && document.fonts.ready) {
-    document.fonts.ready.then(()=>{ setTimeout(initializeGame,50); });
+    const ready = Promise.race([
+      document.fonts.ready,
+      new Promise(resolve => setTimeout(resolve, 1000))
+    ]);
+    ready.then(() => setTimeout(startGame, 50)).catch(startGame);
   } else {
-    setTimeout(initializeGame,150);
+    setTimeout(startGame, 150);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the game initialization runs even if `document.fonts.ready` never resolves
- add error handling to display load errors when initialization fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a5256b08320bc9b56d591e224e7