### PR TITLE
Add basic unit tests for core logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "latvian-lang-b1",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/forge.test.js
+++ b/test/forge.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mulberry32, state } from '../src/state.js';
+
+// minimal DOM stubs for modules that expect a browser environment
+global.document = {
+  getElementById: () => ({
+    getContext: () => ({}),
+    width: 980,
+    height: 560,
+    style: {},
+    parentElement: { offsetWidth: 980 },
+    getBoundingClientRect: () => ({ left: 0, top: 0 })
+  })
+};
+
+const { startForgeRound, ALL_PREFIXES } = await import('../src/forge.js');
+
+// startForgeRound should create a forgeState with correct options
+
+test('startForgeRound sets up forge state correctly', () => {
+  state.DATA = {
+    forge: [
+      { base: 'darit', translations: { en: 'do' }, correct: 'iz', games: ['forge'] }
+    ]
+  };
+  state.roundIndex = 0;
+  state.rng = mulberry32(1);
+
+  startForgeRound();
+
+  const fs = state.forgeState;
+  assert.equal(fs.base, 'darit');
+  assert.equal(fs.en, 'do');
+  assert.equal(fs.correct, 'iz');
+  assert.equal(fs.options.length, 5);
+  assert(fs.options.includes('iz'));
+  assert.equal(new Set(fs.options).size, 5);
+  fs.options.forEach(p => assert(ALL_PREFIXES.includes(p)));
+});

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mulberry32, state, shuffle, choice } from '../src/state.js';
+
+// mulberry32 should produce a deterministic sequence for a given seed
+
+test('mulberry32 produces deterministic values', () => {
+  const rng = mulberry32(1);
+  assert.equal(rng(), 0.6270739405881613);
+  assert.equal(rng(), 0.002735721180215478);
+});
+
+// shuffle should reorder array deterministically with seeded rng
+
+test('shuffle reorders array using state.rng', () => {
+  state.rng = mulberry32(1);
+  const arr = [1, 2, 3, 4, 5];
+  const result = shuffle(arr.slice());
+  assert.deepStrictEqual(result, [5, 3, 2, 1, 4]);
+});
+
+// choice should pick an element based on state.rng
+
+test('choice selects element from array', () => {
+  state.rng = mulberry32(1);
+  const value = choice(['a', 'b', 'c']);
+  assert.equal(value, 'b');
+});


### PR DESCRIPTION
## Summary
- add Node-based test script and enable ES modules
- cover RNG helpers with deterministic tests
- verify forge round initializes options correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc5de9e81c832082acee68031f5339