### PR TITLE
fix: improve mobile layout for verb game

### DIFF
--- a/darbibas-vards.html
+++ b/darbibas-vards.html
@@ -7,14 +7,15 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="stylesheet" href="styles.css" />
   <style>
+    *,*::before,*::after{box-sizing:border-box}
     :root{--bg:#0b0f14;--card:#111827;--muted:#64748b;--text:#e5e7eb;--accent:#2563eb;--accent-2:#22c55e;--warn:#ef4444}
     html,body{height:100%}
-    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,\n    Noto Sans,sans-serif;background:var(--bg);color:var(--text);display:flex;flex-direction:column}
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,\n    Noto Sans,sans-serif;background:var(--bg);color:var(--text);display:flex;flex-direction:column;position:static;overflow-x:hidden;overflow-y:auto;width:100%}
     header{padding:24px 16px;display:flex;gap:12px;align-items:center;justify-content:space-between}
     header .title{font-size:clamp(20px,3vw,28px);font-weight:700}
     header a.btn{color:var(--text);text-decoration:none;border:1px solid #1f2937;padding:10px 14px;border-radius:12px;background:#0f172a}
     main{flex:1;display:grid;place-items:start;gap:24px;padding:0 16px 32px}
-    .panel{width:min(100%,1100px);margin:0 auto;background:var(--card);border:1px solid #1f2937;border-radius:18px;padding:18px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+    .panel{max-width:1100px;width:100%;margin:0 auto;background:var(--card);border:1px solid #1f2937;border-radius:18px;padding:18px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
     .controls{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between}
     .controls .group{display:flex;gap:10px;align-items:center}
     .segmented{display:inline-flex;border:1px solid #1f2937;border-radius:12px;overflow:hidden}


### PR DESCRIPTION
## Summary
- ensure verb matching game renders properly on mobile devices by using border-box sizing and flexible panel width
- override global body rules to allow scrolling and prevent horizontal overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd389f91dc8320b0fc9d7eeb1b8d01