### PR TITLE
Handle empty match decks and cap auto deck size

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -18,9 +18,16 @@ export function startMatchRound(){
     const boxH = isMobile ? 80 : 46;
     const gap = isMobile ? 16 : 14;
     const maxItemsOnScreen = Math.floor(availableHeight / (boxH + gap));
-    maxItems = Math.max(5, Math.min(maxItemsOnScreen, deck.length));
+    maxItems = Math.min(deck.length, Math.max(5, maxItemsOnScreen));
   } else {
     maxItems = Math.min(15, deck.length);
+  }
+  if(maxItems === 0){
+    setStatus('No items to match.');
+    state.matchState = null;
+    clear();
+    resetClicks();
+    return;
   }
   const picks = shuffle(deck.slice()).slice(0,maxItems);
   const left = picks.map(p=>({txt:p.translations.lv, key:p.translations.lv, meta:p}));

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -4,15 +4,24 @@ import { mulberry32, state } from '../src/state.js';
 
 // minimal DOM stubs for modules that expect a browser environment
 global.window = { devicePixelRatio: 1 };
+const canvasEl = {
+  getContext: () => ({ setTransform(){}, measureText(){ return { width: 0 }; }, clearRect(){} }),
+  width: 980,
+  height: 560,
+  style: {},
+  parentElement: { offsetWidth: 980 },
+  getBoundingClientRect: () => ({ left: 0, top: 0 })
+};
+const statusEl = { textContent: '' };
+const srEl = { innerHTML: '' };
+
 global.document = {
-  getElementById: () => ({
-    getContext: () => ({ setTransform(){}, measureText(){ return { width: 0 }; } }),
-    width: 980,
-    height: 560,
-    style: {},
-    parentElement: { offsetWidth: 980 },
-    getBoundingClientRect: () => ({ left: 0, top: 0 })
-  })
+  getElementById: (id) => {
+    if(id === 'canvas') return canvasEl;
+    if(id === 'status') return statusEl;
+    if(id === 'sr-game-state') return srEl;
+    return canvasEl;
+  }
 };
 
 const { startMatchRound } = await import('../src/match.js');
@@ -28,4 +37,30 @@ test('startMatchRound uses target language entries', () => {
   const ms = state.matchState;
   assert.equal(ms.left[0].txt, 'braukt');
   assert.equal(ms.right[0].txt, 'ехать');
+});
+
+test('auto deck size does not exceed available cards', () => {
+  state.DATA = { units: [ { name:'u1', entries:[{ translations:{ lv:'a', en:'a' }, games:['match'] }] } ] };
+  state.targetLang = 'en';
+  state.deckSizeMode = 'auto';
+  state.difficulty = 'practice';
+  state.rng = mulberry32(2);
+
+  startMatchRound();
+  const ms = state.matchState;
+  assert.equal(ms.total, 1);
+});
+
+test('empty deck is handled gracefully', () => {
+  state.DATA = { units: [] };
+  state.targetLang = 'en';
+  state.deckSizeMode = 'auto';
+  state.difficulty = 'practice';
+  state.rng = mulberry32(3);
+  statusEl.textContent = '';
+
+  startMatchRound();
+
+  assert.equal(state.matchState, null);
+  assert.equal(statusEl.textContent, 'No items to match.');
 });


### PR DESCRIPTION
## Summary
- Prevent match mode's auto deck sizing from exceeding available cards
- Early return with status message when no matchable items exist
- Extend match tests for deck size and empty deck scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bebd0fe42c8320b4eeecdbdbc9b0b6