### PR TITLE
Load vocabulary units concurrently

### DIFF
--- a/app.js
+++ b/app.js
@@ -189,11 +189,13 @@ async function loadVocabulary(from='lv', to='en'){
   const idxRes = await fetch(base + 'units.json');
   if(!idxRes.ok) throw new Error('Units index not found');
   const idx = await idxRes.json();
-  const units = [];
-  for(const u of idx.units){
+
+  const unitPromises = idx.units.map(async u => {
     const res = await fetch(base + u.file);
-    if(res.ok){ units.push(await res.json()); }
-  }
+    return res.ok ? await res.json() : null;
+  });
+  const units = (await Promise.all(unitPromises)).filter(Boolean);
+
   const forgeRes = await fetch(base + 'forge.json');
   const forgeData = forgeRes.ok ? await forgeRes.json() : {entries:[], notes:{}};
   state.DATA = { units, forge: forgeData.entries || [], notes: forgeData.notes || {} };


### PR DESCRIPTION
## Summary
- Load vocabulary unit files concurrently using `Promise.all` for faster initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec0b99c908320a339bd47b61fc88d