### PR TITLE
refactor: share DOM stubs across tests

### DIFF
--- a/test/forge.test.js
+++ b/test/forge.test.js
@@ -1,18 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mulberry32, state } from '../src/state.js';
+import { stubForgeDom } from './helpers/dom-stubs.js';
 
-// minimal DOM stubs for modules that expect a browser environment
-global.document = {
-  getElementById: () => ({
-    getContext: () => ({}),
-    width: 980,
-    height: 560,
-    style: {},
-    parentElement: { offsetWidth: 980 },
-    getBoundingClientRect: () => ({ left: 0, top: 0 })
-  })
-};
+stubForgeDom();
 
 const { startForgeRound, ALL_PREFIXES } = await import('../src/forge.js');
 

--- a/test/helpers/dom-stubs.js
+++ b/test/helpers/dom-stubs.js
@@ -1,0 +1,42 @@
+export function stubForgeDom() {
+  global.document = {
+    getElementById: () => ({
+      getContext: () => ({}),
+      width: 980,
+      height: 560,
+      style: {},
+      parentElement: { offsetWidth: 980 },
+      getBoundingClientRect: () => ({ left: 0, top: 0 })
+    })
+  };
+}
+
+export function stubMatchDom() {
+  global.window = { devicePixelRatio: 1 };
+
+  const canvasEl = {
+    getContext: () => ({
+      setTransform() {},
+      measureText() { return { width: 0 }; },
+      clearRect() {}
+    }),
+    width: 980,
+    height: 560,
+    style: {},
+    parentElement: { offsetWidth: 980 },
+    getBoundingClientRect: () => ({ left: 0, top: 0 })
+  };
+  const statusEl = { textContent: '' };
+  const srEl = { innerHTML: '' };
+
+  global.document = {
+    getElementById: (id) => {
+      if (id === 'canvas') return canvasEl;
+      if (id === 'status') return statusEl;
+      if (id === 'sr-game-state') return srEl;
+      return canvasEl;
+    }
+  };
+
+  return { canvasEl, statusEl, srEl };
+}

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -1,28 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mulberry32, state } from '../src/state.js';
+import { stubMatchDom } from './helpers/dom-stubs.js';
 
-// minimal DOM stubs for modules that expect a browser environment
-global.window = { devicePixelRatio: 1 };
-const canvasEl = {
-  getContext: () => ({ setTransform(){}, measureText(){ return { width: 0 }; }, clearRect(){} }),
-  width: 980,
-  height: 560,
-  style: {},
-  parentElement: { offsetWidth: 980 },
-  getBoundingClientRect: () => ({ left: 0, top: 0 })
-};
-const statusEl = { textContent: '' };
-const srEl = { innerHTML: '' };
-
-global.document = {
-  getElementById: (id) => {
-    if(id === 'canvas') return canvasEl;
-    if(id === 'status') return statusEl;
-    if(id === 'sr-game-state') return srEl;
-    return canvasEl;
-  }
-};
+const { statusEl } = stubMatchDom();
 
 const { startMatchRound } = await import('../src/match.js');
 


### PR DESCRIPTION
## Summary
- centralize minimal DOM mock setup for tests
- reuse helper in forge and match tests

## Testing
- ⚠️ `node --test` (command not found)
- ⚠️ `apt-get update` (403 Forbidden while attempting to install Node)


------
https://chatgpt.com/codex/tasks/task_e_68bec838f5c48320ae6e974245e31475