### PR TITLE
Keep language lists side-by-side on mobile

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -20,14 +20,9 @@ padding: 1rem;
 }
 
 .grid-words {
-display: grid;
-grid-template-columns: 1fr 1fr;
-gap: var(--gap);
-}
-@media (max-width: 640px) {
-.grid-words {
-grid-template-columns: 1fr;
-}
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--gap);
 }
 
 .word-card {


### PR DESCRIPTION
## Summary
- Remove mobile media query that collapsed the two language lists into one column
- Maintain two-column grid so Latvian and translation words stay parallel on all screen sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf0a399b0883208be8dcce576af5ff