### PR TITLE
Restore language switching and navigation for Darbības Vārdi game

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5,12 +5,15 @@ const SCORE = document.getElementById("score");
 const BTN_NEW = document.getElementById("btn-new");
 const BTN_SPEAK = document.getElementById("btn-speak");
 const HELP = document.getElementById("help");
+const LANG_SEL = document.getElementById("language-select");
 
 let data = [];
 let current = [];
 let speakOn = false;
 let score = { right: 0, wrong: 0 };
 let sel = { lv: null, tr: null };
+let currentLang = 'eng';
+LANG_SEL && (LANG_SEL.value = currentLang);
 
 // Utils
 const rand = (n) => Math.floor(Math.random() * n);
@@ -30,7 +33,7 @@ LV_BOX.innerHTML = "";
 TR_BOX.innerHTML = "";
 
 const lv = items.map((it, idx) => ({ key: idx, text: it.lv }));
-const tr = items.map((it, idx) => ({ key: idx, text: it.eng || it.ru }));
+const tr = items.map((it, idx) => ({ key: idx, text: it[currentLang] }));
 
 const lvHTML = lv.map(o => cardHTML(o.text, o.key, "lv")).join("");
 const trHTML = shuffled(tr).map(o => cardHTML(o.text, o.key, "tr")).join("");
@@ -115,7 +118,7 @@ if (sel.lv !== null && sel.tr !== null) {
     score.wrong++;
     announceStatus();
     const lvWord = current[sel.lv]?.lv || "";
-    const trCandidate = current[sel.tr]?.eng || current[sel.tr]?.ru || "";
+    const trCandidate = current[sel.tr]?.[currentLang] || "";
     HELP.textContent = `Nē. “${lvWord}” nav “${trCandidate}”. Pamēģini vēlreiz.`;
   }
   // reset selection (but keep disabled pairs)
@@ -188,6 +191,11 @@ BTN_SPEAK?.addEventListener("click", () => {
 speakOn = !speakOn;
 BTN_SPEAK.setAttribute("aria-pressed", String(speakOn));
 BTN_SPEAK.textContent = speakOn ? "Izruna: ieslēgta" : "Ieslēgt izrunu";
+});
+
+LANG_SEL?.addEventListener('change', () => {
+currentLang = LANG_SEL.value;
+renderRound(current);
 });
 
 window.addEventListener("beforeunload", () => {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -26,7 +26,7 @@ padding: 1rem;
 }
 
 .word-card {
-border: 1px solid var(--pico-muted-border-color, rgba(0,0,0,.15));
+border: 1px solid var(--bs-border-color, rgba(0,0,0,.15));
 border-radius: var(--radius);
 padding: .75rem 1rem;
 cursor: pointer;

--- a/darbibas-vards.html
+++ b/darbibas-vards.html
@@ -1,52 +1,108 @@
 <!doctype html>
-<html lang="lv">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Latviešu valoda – Darbības vārdi (B1)</title>
-  <link rel="manifest" href="manifest.json" />
-  <link rel="icon" href="favicon.ico" />
-  <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
-  <link rel="stylesheet" href="assets/styles.css">
-  <script>
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('sw.js').catch(() => {});
-    }
-  </script>
-</head>
-<body>
-  <header class="container">
-    <h1>Latviešu valoda – Darbības vārdi (B1)</h1>
-    <p>Sašauj latviešu vārdu ar tulkojumu. Strādā ar peli vai tastatūru.</p>
-  </header>
+<html lang="lv" data-bs-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+    <meta name="theme-color" content="#0e0f13" />
+    <title>Latviešu valoda – Darbības Vārdi (B1)</title>
+    <link rel="manifest" href="manifest.json" />
+    <link rel="icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.13.1/font/bootstrap-icons.min.css" rel="stylesheet" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('sw.js').catch(() => {});
+      }
+    </script>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top border-bottom">
+      <div class="container">
+        <a class="navbar-brand d-flex align-items-center gap-2" href="index.html">
+          <i class="bi bi-translate"></i> Latvian B1
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNav" aria-controls="offcanvasNav" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNav" aria-labelledby="offcanvasNavLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="offcanvasNavLabel">Menu</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+          </div>
+          <div class="offcanvas-body align-items-lg-center">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+              <li class="nav-item"><a class="nav-link active" aria-current="page" href="darbibas-vards.html">Darbības Vārds</a></li>
+              <li class="nav-item"><a class="nav-link" href="week1.html">Week 1</a></li>
+            </ul>
+            <div class="d-flex gap-2">
+              <button id="themeToggle" class="btn btn-outline-secondary" type="button" aria-label="Toggle color mode">
+                <i class="bi bi-moon-stars-fill d-none" id="iconDark"></i>
+                <i class="bi bi-sun-fill" id="iconLight"></i>
+              </button>
+              <a class="btn btn-primary" href="https://github.com/oerbey/Latvian_Lang_B1" target="_blank" rel="noopener">
+                <i class="bi bi-github"></i> <span class="ms-1 d-none d-sm-inline">GitHub</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
 
-  <main class="container">
-    <section aria-labelledby="status-heading">
-      <h2 id="status-heading" class="sr-only">Statuss</h2>
-      <div id="score" class="status" aria-live="polite">Pareizi: 0 | Nepareizi: 0</div>
-    </section>
+    <main class="container py-4 mt-5">
+      <header class="mb-4">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-end gap-2">
+          <div>
+            <h1 class="h4 mb-1">Latviešu valoda – Darbības Vārdi (B1)</h1>
+            <p class="mb-0">Sašauj latviešu vārdu ar tulkojumu. Strādā ar peli vai tastatūru.</p>
+          </div>
+          <select id="language-select" class="form-select w-auto" aria-label="Language selection">
+            <option value="eng">English</option>
+            <option value="ru">Русский</option>
+          </select>
+        </div>
+      </header>
 
-    <section class="grid-words" aria-label="Vārdu saraksti">
-      <div id="list-lv" role="listbox" aria-label="Latviešu vārdi"></div>
-      <div id="list-tr" role="listbox" aria-label="Tulkojumi"></div>
-    </section>
+      <section aria-labelledby="status-heading">
+        <h2 id="status-heading" class="sr-only">Statuss</h2>
+        <div id="score" class="status" aria-live="polite">Pareizi: 0 | Nepareizi: 0</div>
+      </section>
 
-    <section style="margin-top:1rem;">
-      <button id="btn-new" class="contrast">Jauna spēle</button>
-      <button id="btn-speak" aria-pressed="false">Ieslēgt izrunu</button>
-    </section>
+      <section class="grid-words" aria-label="Vārdu saraksti">
+        <div id="list-lv" role="listbox" aria-label="Latviešu vārdi"></div>
+        <div id="list-tr" role="listbox" aria-label="Tulkojumi"></div>
+      </section>
 
-    <section aria-labelledby="help-heading" style="margin-top:1rem;">
-      <h2 id="help-heading" class="sr-only">Palīdzība</h2>
-      <div id="help" aria-live="polite"></div>
-    </section>
-  </main>
+      <section class="mt-3">
+        <button id="btn-new" class="btn btn-primary me-2">Jauna spēle</button>
+        <button id="btn-speak" class="btn btn-secondary" aria-pressed="false">Ieslēgt izrunu</button>
+      </section>
 
-  <footer class="container">
-    <small>&copy; Latvijas valodas treniņš (B1)</small>
-  </footer>
+      <section aria-labelledby="help-heading" class="mt-3">
+        <h2 id="help-heading" class="sr-only">Palīdzība</h2>
+        <div id="help" aria-live="polite"></div>
+      </section>
+    </main>
 
-  <script src="assets/app.js" defer></script>
-</body>
+    <footer class="border-top py-4 bg-body-tertiary">
+      <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center gap-3">
+        <span class="text-secondary">© <span id="year"></span> Latvian B1 Games</span>
+        <nav class="small">
+          <a class="link-secondary me-3" href="index.html">Home</a>
+          <a class="link-secondary me-3" href="darbibas-vards.html">Verbs</a>
+          <a class="link-secondary" href="week1.html">Week 1</a>
+        </nav>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/app.js" defer></script>
+    <script src="theme.js"></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <div class="offcanvas-body align-items-lg-center">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
               <li class="nav-item"><a class="nav-link active" aria-current="page" href="index.html">Home</a></li>
-              <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības vārds</a></li>
+              <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības Vārds</a></li>
               <li class="nav-item"><a class="nav-link" href="week1.html">Week 1</a></li>
             </ul>
 
@@ -97,7 +97,7 @@
 
       // List your games here (title, link, icon, desc)
       const games = [
-        { title: 'Darbības vārds', href: 'darbibas-vards.html', icon: 'bi-joystick', desc: 'Verb practice game' },
+        { title: 'Darbības Vārds', href: 'darbibas-vards.html', icon: 'bi-joystick', desc: 'Verb practice game' },
         { title: 'Week 1', href: 'week1.html', icon: 'bi-lightning-charge', desc: 'Weekly exercises' },
         // { title: 'Nouns', href: 'lietvardi.html', icon: 'bi-book', desc: 'Noun practice' },
       ];

--- a/week1.html
+++ b/week1.html
@@ -38,7 +38,7 @@ if ('serviceWorker' in navigator) {
       <div class="offcanvas-body align-items-lg-center">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <li class="nav-item"><a class="nav-link active" aria-current="page" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības vārds</a></li>
+          <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības Vārds</a></li>
           <li class="nav-item"><a class="nav-link" href="week1.html">Week 1</a></li>
         </ul>
 


### PR DESCRIPTION
## Summary
- Reintroduce full Bootstrap navigation and footer to Darbības Vārdi page and add language selector with styled buttons.
- Enable dynamic translation switching in verb game logic and improve button contrast.
- Capitalize "Darbības Vārds" across site.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf1518c52c8320957caf5844e4d785