### PR TITLE
Reset verb-match counters and add word count option

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -6,6 +6,7 @@ const BTN_NEW = document.getElementById("btn-new");
 const BTN_SPEAK = document.getElementById("btn-speak");
 const HELP = document.getElementById("help");
 const LANG_SEL = document.getElementById("language-select");
+const COUNT_SEL = document.getElementById("count-select");
 
 let data = [];
 let current = [];
@@ -156,12 +157,13 @@ if (card) handleSelect(card);
 
 async function newGame() {
 HELP.textContent = "";
-score = JSON.parse(localStorage.getItem("score") || '{"right":0,"wrong":0}');
+score = { right: 0, wrong: 0 };
 announceStatus();
 
+sel = { lv: null, tr: null };
+
 const sample = [];
-// Choose 8–12 random items for each round
-const COUNT = 10;
+const COUNT = Number(COUNT_SEL?.value || 10);
 const used = new Set();
 while (sample.length < Math.min(COUNT, data.length)) {
   const i = rand(data.length);
@@ -198,8 +200,8 @@ currentLang = LANG_SEL.value;
 renderRound(current);
 });
 
-window.addEventListener("beforeunload", () => {
-localStorage.setItem("score", JSON.stringify(score));
+COUNT_SEL?.addEventListener('change', () => {
+newGame();
 });
 
 // Bootstrap the app

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -26,25 +26,30 @@ padding: 1rem;
 }
 
 .word-card {
-border: 1px solid var(--bs-border-color, rgba(0,0,0,.15));
-border-radius: var(--radius);
-padding: .75rem 1rem;
-cursor: pointer;
-user-select: none;
-transition: transform 120ms ease, outline-color 120ms ease;
+  background: #2a2f3a;
+  border: 2px solid #445066;
+  border-radius: var(--radius);
+  padding: .75rem 1rem;
+  color: #e9eef5;
+  cursor: pointer;
+  user-select: none;
+  transition: transform 120ms ease, background-color 120ms ease, border-color 120ms ease;
 }
-.word-card:hover { transform: translateY(-1px); }
-.word-card:active { transform: scale(0.98); }
+.word-card:hover:not([aria-disabled="true"]) { transform: translateY(-1px); }
+.word-card:active:not([aria-disabled="true"]) { transform: scale(0.98); }
 
 .word-card[aria-pressed="true"],
 .word-card.selected {
-outline: 2px solid var(--accent);
-outline-offset: 3px;
+  background: #1c7ed6;
+  border-color: #1c7ed6;
 }
 
 .word-card[aria-disabled="true"] {
-opacity: .45;
-cursor: not-allowed;
+  background: #1e2530;
+  border-color: #3a4657;
+  color: #7d8aa0;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .sr-only {

--- a/darbibas-vards.html
+++ b/darbibas-vards.html
@@ -58,10 +58,18 @@
             <h1 class="h4 mb-1">Latviešu valoda – Darbības Vārdi (B1)</h1>
             <p class="mb-0">Sašauj latviešu vārdu ar tulkojumu. Strādā ar peli vai tastatūru.</p>
           </div>
-          <select id="language-select" class="form-select w-auto" aria-label="Language selection">
-            <option value="eng">English</option>
-            <option value="ru">Русский</option>
-          </select>
+          <div class="d-flex gap-2">
+            <select id="language-select" class="form-select w-auto" aria-label="Language selection">
+              <option value="eng">English</option>
+              <option value="ru">Русский</option>
+            </select>
+            <select id="count-select" class="form-select w-auto" aria-label="Word count">
+              <option value="6">6</option>
+              <option value="8">8</option>
+              <option value="10" selected>10</option>
+              <option value="12">12</option>
+            </select>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- reset score on each new verb matching game and page load
- let players choose how many word pairs to match
- restyle verb match cards to Match Rush look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf18cebd3c832087c027063b367128