### PR TITLE
Allow vertical scroll to propagate

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,26 +139,28 @@ function setupEventListeners(){
   let touchStartScrollY = 0;
   let touchStartTime = 0;
   let touchMoved = false;
-  canvas.addEventListener('touchstart', e=>{
-    const t=e.touches[0];
-    const coords = getCanvasCoordinates(t.clientX, t.clientY);
-    touchStartY = t.clientY; touchStartTime = Date.now();
-    touchStartScrollY = state.matchState ? state.matchState.scrollY : 0;
-    touchMoved = false;
-  }, { passive: false });
-  canvas.addEventListener('touchmove', e=>{
-    const t = e.touches[0];
-    const dy = t.clientY - touchStartY;
-    if(Math.abs(dy) > 5) touchMoved = true;
-    if(state.mode === MODES.MATCH && state.matchState){
-      const ms = state.matchState;
-      const viewH = ms.viewBottom - ms.viewTop;
-      const maxScroll = Math.max(0, ms.contentH - viewH);
-      ms.scrollY = Math.max(0, Math.min(maxScroll, touchStartScrollY - dy));
-      triggerRedraw();
-      e.preventDefault();
-    }
-  }, { passive: false });
+    canvas.addEventListener('touchstart', e=>{
+      const t=e.touches[0];
+      getCanvasCoordinates(t.clientX, t.clientY);
+      touchStartY = t.clientY; touchStartTime = Date.now();
+      touchStartScrollY = state.matchState ? state.matchState.scrollY : 0;
+      touchMoved = false;
+    }, { passive: true });
+    canvas.addEventListener('touchmove', e=>{
+      const t = e.touches[0];
+      const dy = t.clientY - touchStartY;
+      if(Math.abs(dy) > 5) touchMoved = true;
+      if(state.mode === MODES.MATCH && state.matchState){
+        const ms = state.matchState;
+        const viewH = ms.viewBottom - ms.viewTop;
+        const maxScroll = Math.max(0, ms.contentH - viewH);
+        ms.scrollY = Math.max(0, Math.min(maxScroll, touchStartScrollY - dy));
+        triggerRedraw();
+        if (maxScroll > 0) {
+          e.preventDefault();
+        }
+      }
+    }, { passive: false });
   canvas.addEventListener('touchend', e=>{
     const dt = Date.now()-touchStartTime;
     if(dt<200 && !touchMoved){
@@ -168,15 +170,17 @@ function setupEventListeners(){
       if(hit&&hit.onClick){ hit.onClick({ x: coords.x, y: coords.y, target: hit }); e.preventDefault(); }
     }
   }, { passive: false });
-  canvas.addEventListener('wheel', e=>{
-    if(state.mode !== MODES.MATCH || !state.matchState) return;
-    const ms = state.matchState;
-    const viewH = ms.viewBottom - ms.viewTop;
-    const maxScroll = Math.max(0, ms.contentH - viewH);
-    ms.scrollY = Math.max(0, Math.min(maxScroll, ms.scrollY + e.deltaY));
-    triggerRedraw();
-    e.preventDefault();
-  }, { passive: false });
+    canvas.addEventListener('wheel', e=>{
+      if(state.mode !== MODES.MATCH || !state.matchState) return;
+      const ms = state.matchState;
+      const viewH = ms.viewBottom - ms.viewTop;
+      const maxScroll = Math.max(0, ms.contentH - viewH);
+      ms.scrollY = Math.max(0, Math.min(maxScroll, ms.scrollY + e.deltaY));
+      triggerRedraw();
+      if (maxScroll > 0) {
+        e.preventDefault();
+      }
+    }, { passive: false });
   window.addEventListener('resize', ()=>{ updateCanvasScale(); triggerRedraw(); });
   document.addEventListener('keydown', e=>{
     if(e.key==='1'){ state.mode=MODES.MATCH; startMatchRound(); }

--- a/styles.css
+++ b/styles.css
@@ -84,7 +84,7 @@
     }
     
     #wrap {
-      height: 100vh;
+      min-height: 100dvh;
       height: -webkit-fill-available;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
@@ -151,3 +151,20 @@ html, body { height: 100%; scroll-behavior: smooth; }
 /* Card spacing harmony */
 .card .btn { pointer-events: none; } /* button-like label without stealing click */
 a .card { border: 1px solid var(--bs-border-color); }
+
+/* Mobile scroll-trap fix */
+#list-lv,
+#list-tr {
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Make sure no ancestor blocks scroll chaining */
+html, body, .page, .screen {
+  overscroll-behavior-y: auto;
+}
+
+/* Viewport height adjustment */
+.page {
+  min-height: 100dvh;
+}


### PR DESCRIPTION
## Summary
- Ensure list containers allow vertical scrolling by adding pan-y touch action and overscroll-behavior rules.
- Replace fixed 100vh wrapper height with dynamic 100dvh for safer mobile viewport handling.
- Scope canvas touch and wheel handlers to only cancel default when content can scroll.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf2ce649288320ad709f1d2265c7ec