### PR TITLE
Prevent mobile scroll traps and clean up blocking styles

### DIFF
--- a/darbibas-vards.html
+++ b/darbibas-vards.html
@@ -111,6 +111,82 @@
     <script>
       document.getElementById('year').textContent = new Date().getFullYear();
     </script>
+    <script>
+    /**
+     * Anti-scroll-trap for mobile:
+     * - Never cancel vertical swipes.
+     * - Allow horizontal gestures (for sliders) to preventDefault.
+     * - Runs on every element that can vertically scroll OR that might capture touches.
+     */
+    (function () {
+      // Make sure the page itself is allowed to scroll
+      document.documentElement.style.overflowY = 'auto';
+      document.body.style.overflowY = 'auto';
+
+      // If any ancestor wrongly sets touch-action:none, neutralize it up the chain of likely containers.
+      const neutralizeTouchAction = (el) => {
+        for (let n = el; n; n = n.parentElement) {
+          const ta = getComputedStyle(n).touchAction;
+          if (ta && ta.includes('none')) n.style.touchAction = 'auto';
+        }
+      };
+
+      // Find likely scrollable containers (no hard-coded class names needed)
+      const candidates = Array.from(document.querySelectorAll('*')).filter(el => {
+        const cs = getComputedStyle(el);
+        return /(auto|scroll)/.test(cs.overflowY) || /(auto|scroll)/.test(cs.overflow);
+      });
+
+      // Also include any big/fullscreen fixed elements that might eat touches
+      const fullscreenFixed = Array.from(document.querySelectorAll('*')).filter(el => {
+        const cs = getComputedStyle(el);
+        if (cs.position !== 'fixed') return false;
+        const r = el.getBoundingClientRect();
+        return r.top <= 0 && r.left <= 0 &&
+               r.right >= window.innerWidth && r.bottom >= window.innerHeight;
+      });
+
+      const targets = [...new Set([...candidates, ...fullscreenFixed])];
+      if (targets.length === 0) return;
+
+      targets.forEach(el => {
+        // Encourage browsers (esp. iOS Safari) to treat vertical pan as the default
+        el.style.webkitOverflowScrolling = 'touch';
+        // Let vertical panning through; allow pinch-zoom
+        if (!getComputedStyle(el).touchAction || getComputedStyle(el).touchAction === 'auto') {
+          el.style.touchAction = 'pan-y pinch-zoom';
+        }
+        neutralizeTouchAction(el);
+
+        let sx = 0, sy = 0;
+        el.addEventListener('touchstart', (e) => {
+          const t = e.touches[0];
+          sx = t.clientX; sy = t.clientY;
+        }, { passive: true });
+
+        el.addEventListener('touchmove', (e) => {
+          const t = e.touches[0];
+          const dx = Math.abs(t.clientX - sx);
+          const dy = Math.abs(t.clientY - sy);
+
+          const isHorizontal = dx > dy;
+          // Only suppress default for horizontal gestures (e.g., custom sliders).
+          if (isHorizontal) {
+            e.preventDefault(); // requires passive:false
+          }
+          // If the element itself cannot scroll vertically, let the event bubble so the page can scroll.
+          // (Do NOT call preventDefault here.)
+        }, { passive: false });
+      });
+
+      // Safety net: if the focused area still can't scroll and fills the screen exactly,
+      // make sure there's ever-so-slight page scroll available to escape the trap.
+      const root = document.scrollingElement || document.documentElement;
+      if (root.scrollHeight <= root.clientHeight) {
+        document.body.style.minHeight = 'calc(100dvh + 1px)';
+      }
+    })();
+    </script>
   </body>
 </html>
 

--- a/styles.css
+++ b/styles.css
@@ -76,19 +76,12 @@
       user-select: none;
     }
     
-    /* Fix iOS Safari bounce scrolling */
-    body {
-      overflow: hidden;
-      position: fixed;
-      width: 100%;
-    }
-    
-    #wrap {
-      min-height: 100dvh;
-      height: -webkit-fill-available;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
-    }
+      #wrap {
+        min-height: 100dvh;
+        height: -webkit-fill-available;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
   }
 
   /* High DPI displays (Retina, etc.) */
@@ -148,23 +141,33 @@ html, body { height: 100%; scroll-behavior: smooth; }
 :root, [data-bs-theme="light"] { --brand-accent: #0d6efd; }
 [data-bs-theme="dark"] { --brand-accent: #66b2ff; }
 
-/* Card spacing harmony */
-.card .btn { pointer-events: none; } /* button-like label without stealing click */
-a .card { border: 1px solid var(--bs-border-color); }
+  /* Card spacing harmony */
+  .card .btn { pointer-events: none; } /* button-like label without stealing click */
+  a .card { border: 1px solid var(--bs-border-color); }
 
-/* Mobile scroll-trap fix */
-#list-lv,
-#list-tr {
+/* Page must be scrollable unless you explicitly open a modal */
+html, body {
+  min-height: 100%;
+  overflow-y: auto;
+  overscroll-behavior-y: auto; /* allow scroll chaining instead of trapping */
+}
+
+/* If you use full-screen sections, avoid a hard 100vh; use dynamic viewport units */
+.section,
+.page,
+.screen {
+  min-height: 100dvh;
+}
+
+/* Any hidden overlays/backdrops must not eat touches */
+.is-hidden,
+.hidden,
+[aria-hidden="true"] {
+  pointer-events: none !important;
+}
+
+/* Your list wrapper(s) should allow vertical panning */
+.word-list, .list, .list-container, .items, [data-role="list"] {
   touch-action: pan-y;
   -webkit-overflow-scrolling: touch;
-}
-
-/* Make sure no ancestor blocks scroll chaining */
-html, body, .page, .screen {
-  overscroll-behavior-y: auto;
-}
-
-/* Viewport height adjustment */
-.page {
-  min-height: 100dvh;
 }


### PR DESCRIPTION
## Summary
- Add anti-scroll-trap script so vertical swipes always scroll while horizontal gestures can prevent default
- Ensure page and lists remain scrollable with CSS tweaks
- Remove iOS-specific rules that hid page overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf30ada2d88320af5c6259aff14ead