### PR TITLE
Externalize service worker registration

### DIFF
--- a/darbibas-vards.html
+++ b/darbibas-vards.html
@@ -12,11 +12,6 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.13.1/font/bootstrap-icons.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="assets/styles.css" />
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('sw.js').catch(() => {});
-      }
-    </script>
   </head>
   <body>
     <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top border-bottom">

--- a/index.html
+++ b/index.html
@@ -15,12 +15,6 @@
 
     <!-- Project styles -->
     <link rel="stylesheet" href="styles.css" />
-    <script>
-      if ('serviceWorker' in navigator) {
-        // keep your existing sw.js behavior
-        navigator.serviceWorker.register('sw.js').catch(() => {});
-      }
-    </script>
   </head>
   <body>
     <!-- Navbar with offcanvas (mobile) -->
@@ -90,6 +84,7 @@
     <!-- Your scripts -->
     <script src="app.js"></script>
     <script src="theme.js"></script>
+    <script src="scripts/page-init.js" defer></script>
 
     <script>
       // Footer year

--- a/scripts/page-init.js
+++ b/scripts/page-init.js
@@ -75,3 +75,10 @@ document.getElementById('year').textContent = new Date().getFullYear();
   }
 })();
 
+// Register the service worker after the window has fully loaded
+window.addEventListener('load', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').catch(() => {});
+  }
+});
+

--- a/week1.html
+++ b/week1.html
@@ -13,11 +13,6 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.13.1/font/bootstrap-icons.min.css" rel="stylesheet">
 <link rel="stylesheet" href="styles.css">
-<script>
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').catch(() => {});
-}
-</script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top border-bottom">
@@ -104,9 +99,7 @@ if ('serviceWorker' in navigator) {
 <!-- Bootstrap bundle (incl. Popper) -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 <script type="module" src="app.js"></script>
-<script>
-  document.getElementById('year').textContent = new Date().getFullYear();
-</script>
 <script src="theme.js"></script>
+<script src="scripts/page-init.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move service worker registration into `scripts/page-init.js`
- load `page-init.js` on pages instead of using inline service worker scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac253c6c83209fddec5ece77f24a