### PR TITLE
Fix landing page and Conjugation Sprint buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,76 +37,9 @@
           <div class="offcanvas-body align-items-lg-center">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
               <li class="nav-item"><a class="nav-link active" aria-current="page" href="index.html">Home</a></li>
-                            <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības Vārds</a></li>
+              <li class="nav-item"><a class="nav-link" href="darbibas-vards.html">Darbības Vārds</a></li>
               <li class="nav-item"><a class="nav-link" href="conjugation-sprint.html">Conjugation Sprint</a></li>
               <li class="nav-item"><a class="nav-link" href="week1.html">Week 1</a></li>
-            </ul>
-            <div class="d-flex gap-2">
-              <button id="themeToggle" class="btn btn-outline-secondary" type="button" aria-label="Toggle color mode">
-                <i class="bi bi-moon-stars-fill d-none" id="iconDark"></i>
-                <i class="bi bi-sun-fill" id="iconLight"></i>
-              </button>
-              <a class="btn btn-primary" href="https://github.com/oerbey/Latvian_Lang_B1" target="_blank" rel="noopener">
-                <i class="bi bi-github"></i> <span class="ms-1 d-none d-sm-inline">GitHub</span>
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
-
-    <main class="container py-4 mt-5">
-      <div class="p-5 mb-4 bg-body-tertiary rounded-3">
-        <div class="container-fluid py-5">
-          <h1 class="display-5 fw-bold">Latvian Language B1 Level</h1>
-          <p class="col-md-8 fs-4">
-            This page contains a collection of games and exercises to help you practice your Latvian language skills at the B1 level.
-          </p>
-        </div>
-      </div>
-
-      <div class="row align-items-md-stretch">
-        <div class="col-md-6 mb-4">
-          <div class="h-100 p-5 text-bg-dark rounded-3">
-            <h2>Darbības Vārdi</h2>
-            <p>Match the Latvian verb with its translation. Work with a mouse or keyboard.</p>
-            <a class="btn btn-outline-light" href="darbibas-vards.html">Play Game</a>
-          </div>
-        </div>
-        <div class="col-md-6 mb-4">
-          <div class="h-100 p-5 bg-body-tertiary border rounded-3">
-            <h2>Conjugation Sprint</h2>
-            <p>Focus: verbs with full paradigms (present • past • future). Data from your <code>words.json</code>.</p>
-            <a class="btn btn-outline-secondary" href="conjugation-sprint.html">Play Game</a>
-          </div>
-        </div>
-        <div class="col-md-6 mb-4">
-          <div class="h-100 p-5 bg-body-tertiary border rounded-3">
-            <h2>Week 1</h2>
-            <p>Practice the vocabulary from the first week of the B1 course.</p>
-            <a class="btn btn-outline-secondary" href="week1.html">Practice</a>
-          </div>
-        </div>
-      </div>
-    </main>
-
-    <footer class="border-top py-4 bg-body-tertiary">
-      <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center gap-3">
-        <span class="text-secondary">© <span id="year"></span> Latvian B1 Games</span>
-        <nav class="small">
-          <a class="link-secondary me-3" href="index.html">Home</a>
-          <a class="link-secondary me-3" href="darbibas-vards.html">Verbs</a>
-          <a class="link-secondary" href="week1.html">Week 1</a>
-        </nav>
-      </div>
-    </footer>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="theme.js"></script>
-    <script src="scripts/page-init.js" defer></script>
-  </body>
-</html>
-
             </ul>
 
             <div class="d-flex gap-2">
@@ -141,6 +74,7 @@
         <nav class="small">
           <a class="link-secondary me-3" href="index.html">Home</a>
           <a class="link-secondary me-3" href="darbibas-vards.html">Verbs</a>
+          <a class="link-secondary me-3" href="conjugation-sprint.html">Conjugation Sprint</a>
           <a class="link-secondary" href="week1.html">Week 1</a>
         </nav>
       </div>
@@ -161,6 +95,7 @@
       // List your games here (title, link, icon, desc)
       const games = [
         { title: 'Darbības Vārds', href: 'darbibas-vards.html', icon: 'bi-joystick', desc: 'Verb practice game' },
+        { title: 'Conjugation Sprint', href: 'conjugation-sprint.html', icon: 'bi-speedometer2', desc: 'Verb conjugation race' },
         { title: 'Week 1', href: 'week1.html', icon: 'bi-lightning-charge', desc: 'Weekly exercises' },
         // { title: 'Nouns', href: 'lietvardi.html', icon: 'bi-book', desc: 'Noun practice' },
       ];

--- a/styles.css
+++ b/styles.css
@@ -142,8 +142,8 @@ html, body { height: 100%; scroll-behavior: smooth; }
 [data-bs-theme="dark"] { --brand-accent: #66b2ff; }
 
   /* Card spacing harmony */
-  .card .btn { pointer-events: none; } /* button-like label without stealing click */
-  a .card { border: 1px solid var(--bs-border-color); }
+  #gamesGrid .card .btn { pointer-events: none; } /* button-like label without stealing click */
+  #gamesGrid a .card { border: 1px solid var(--bs-border-color); }
 
 /* Page must be scrollable unless you explicitly open a modal */
 html, body {


### PR DESCRIPTION
## Summary
- Restore original landing page layout and add Conjugation Sprint navigation & card
- Limit pointer-events rule to landing page grid so game buttons work again

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b9ea0df4832098a5490512eea0e7