### PR TITLE
Fix Week 1 vocabulary units index JSON

### DIFF
--- a/data/lv-en/units.json
+++ b/data/lv-en/units.json
@@ -41,5 +41,4 @@
       "file": "units/week1-movements.json"
     }
   ]
-  ]
 }


### PR DESCRIPTION
## Summary
- remove the duplicated closing bracket from `data/lv-en/units.json`
- restore valid JSON so the Week 1 vocabulary data loads correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb2bac6608320b4de62af627f7cc9