### PR TITLE
Fix invalid LV→EN units index JSON

### DIFF
--- a/data/lv-en/units.json
+++ b/data/lv-en/units.json
@@ -41,5 +41,5 @@
       "file": "units/week1-movements.json"
     }
   ]
-  ]
 }
+


### PR DESCRIPTION
## Summary
- remove the extra closing bracket in `data/lv-en/units.json` so the LV→EN vocabulary index parses correctly again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbbe13194c83209e60d1b3ad776a8e