### PR TITLE
Add Darbības Vārdi V2 adaptive verb trainer

### DIFF
--- a/darbibas-vardi-v2.html
+++ b/darbibas-vardi-v2.html
@@ -1,0 +1,327 @@
+<!--
+  darbibas-vardi-v2.html — Darbības Vārdi V2.
+  Mobile-first adaptive Latvian verb trainer: a per-verb Leitner ladder that
+  moves from meaning, to conjugated form, to assembling a form from parts.
+  Entry script: src/games/darbibas-vardi-v2/index.js
+-->
+<!doctype html>
+<html lang="lv" data-bs-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' https:; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; font-src 'self' https: data:; object-src 'none'; base-uri 'self';"
+    />
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+    <meta name="theme-color" content="#f4f6fb" />
+    <meta
+      name="description"
+      content="Darbības Vārdi V2 — adaptīvs latviešu darbības vārdu treniņš ar atkārtošanas intervāliem, formu izvēli un formu salikšanu."
+    />
+    <title>Darbības Vārdi V2 — Latvian B Level</title>
+    <link rel="manifest" href="manifest.json" />
+    <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="assets/icons/icon-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="assets/icons/icon-512.png" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="src/games/darbibas-vardi-v2/styles.css" />
+  </head>
+  <body class="dp-page game-theme dv2-page">
+    <a class="dp-skip" href="#main">Skip to main content</a>
+
+    <nav data-site-nav></nav>
+
+    <main id="main">
+      <div class="dv2-app" data-darbibas-vardi-v2>
+        <div id="dv2-error" class="dv2-error" role="alert" hidden></div>
+        <p id="dv2-live" class="visually-hidden" role="status" aria-live="polite"></p>
+
+        <section class="dv2-screen dv2-start" data-screen="start" aria-labelledby="dv2-title">
+          <header class="dv2-hero">
+            <span class="dv2-eyebrow">Adaptīvais treniņš</span>
+            <h1 id="dv2-title" class="dv2-title">Darbības Vārdi V2</h1>
+            <p class="dv2-lead">
+              Katrs darbības vārds ceļo pa savu prasmju kāpni. Kļūdas atgriežas uzreiz, zināmie
+              vārdi atgriežas pēc dienām.
+            </p>
+          </header>
+
+          <div class="dv2-stat-row" aria-label="Tavs progress">
+            <div class="dv2-stat">
+              <strong id="dv2-xp">0</strong>
+              <span>XP</span>
+            </div>
+            <div class="dv2-stat">
+              <strong id="dv2-daily-streak">0</strong>
+              <span>dienu sērija</span>
+            </div>
+            <div class="dv2-stat">
+              <strong id="dv2-best-streak">0</strong>
+              <span>labākā sērija</span>
+            </div>
+          </div>
+
+          <section class="dv2-panel" aria-labelledby="dv2-deck-heading">
+            <h2 id="dv2-deck-heading" class="dv2-panel__title">Tava kava</h2>
+            <div class="dv2-deck-grid">
+              <div class="dv2-deck-cell dv2-deck-cell--due">
+                <strong id="dv2-due-count">0</strong>
+                <span>atkārtot tagad</span>
+              </div>
+              <div class="dv2-deck-cell">
+                <strong id="dv2-learning-count">0</strong>
+                <span>mācās</span>
+              </div>
+              <div class="dv2-deck-cell">
+                <strong id="dv2-mastered-count">0</strong>
+                <span>apgūti</span>
+              </div>
+              <div class="dv2-deck-cell">
+                <strong id="dv2-fresh-count">0</strong>
+                <span>vēl nesākti</span>
+              </div>
+            </div>
+            <div class="dv2-mastery" aria-hidden="true">
+              <span id="dv2-mastery-bar"></span>
+            </div>
+            <p id="dv2-deck-note" class="dv2-note">Ielādē vārdu krājumu…</p>
+          </section>
+
+          <section class="dv2-panel" aria-labelledby="dv2-ladder-heading">
+            <h2 id="dv2-ladder-heading" class="dv2-panel__title">Prasmju kāpne</h2>
+            <ol class="dv2-ladder">
+              <li>
+                <strong>Nozīme</strong>
+                <span>Sasaisti darbības vārdu ar tulkojumu abos virzienos.</span>
+              </li>
+              <li>
+                <strong>Forma</strong>
+                <span>Izvēlies pareizo personu un laiku starp līdzīgām formām.</span>
+              </li>
+              <li>
+                <strong>Būve</strong>
+                <span>Saliec formu no saknes un galotnes.</span>
+              </li>
+            </ol>
+          </section>
+
+          <section class="dv2-panel" aria-labelledby="dv2-settings-heading">
+            <h2 id="dv2-settings-heading" class="dv2-panel__title">Iestatījumi</h2>
+
+            <div class="dv2-setting">
+              <span id="dv2-language-label" class="dv2-setting__label">Tulkojuma valoda</span>
+              <div class="dv2-segment" role="group" aria-labelledby="dv2-language-label">
+                <button
+                  id="dv2-lang-en"
+                  class="dv2-segment__btn"
+                  type="button"
+                  data-language="en"
+                  aria-pressed="true"
+                >
+                  English
+                </button>
+                <button
+                  id="dv2-lang-ru"
+                  class="dv2-segment__btn"
+                  type="button"
+                  data-language="ru"
+                  aria-pressed="false"
+                >
+                  Русский
+                </button>
+              </div>
+            </div>
+
+            <div class="dv2-setting">
+              <span class="dv2-setting__label">Izruna</span>
+              <button id="dv2-speech-toggle" class="dv2-switch" type="button" aria-pressed="false">
+                <span class="dv2-switch__track" aria-hidden="true"></span>
+                <span class="dv2-switch__text">Izslēgta</span>
+              </button>
+            </div>
+
+            <div class="dv2-setting">
+              <span class="dv2-setting__label">Vibrācija</span>
+              <button id="dv2-haptics-toggle" class="dv2-switch" type="button" aria-pressed="true">
+                <span class="dv2-switch__track" aria-hidden="true"></span>
+                <span class="dv2-switch__text">Ieslēgta</span>
+              </button>
+            </div>
+          </section>
+
+          <div class="dv2-cta">
+            <button id="dv2-start" class="dv2-primary" type="button">Sākt treniņu</button>
+            <button id="dv2-reset" class="dv2-ghost" type="button">Notīrīt progresu</button>
+          </div>
+        </section>
+
+        <section class="dv2-screen dv2-play" data-screen="play" aria-label="Uzdevums" hidden>
+          <header class="dv2-hud">
+            <button id="dv2-quit" class="dv2-icon-btn" type="button" aria-label="Beigt raundu">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M15 6l-6 6 6 6" />
+              </svg>
+            </button>
+
+            <div class="dv2-hud__main">
+              <div class="dv2-hud__line">
+                <span id="dv2-stage-label" class="dv2-stage-chip">Nozīme</span>
+                <strong id="dv2-progress-text">0/0</strong>
+              </div>
+              <div
+                id="dv2-progress"
+                class="dv2-progress"
+                role="progressbar"
+                aria-label="Raunda progress"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="0"
+              >
+                <span id="dv2-progress-bar"></span>
+              </div>
+            </div>
+
+            <div class="dv2-mini-stats" aria-label="Raunda rezultāts">
+              <span><small>XP</small><strong id="dv2-round-xp">0</strong></span>
+              <span><small>Sērija</small><strong id="dv2-streak">0</strong></span>
+            </div>
+          </header>
+
+          <article id="dv2-card" class="dv2-card">
+            <div class="dv2-card__head">
+              <p id="dv2-prompt-label" class="dv2-prompt-label">Ko nozīmē šis darbības vārds?</p>
+              <button
+                id="dv2-speak"
+                class="dv2-icon-btn dv2-icon-btn--soft"
+                type="button"
+                aria-label="Noklausīties izrunu"
+                hidden
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M4 9v6h4l5 4V5L8 9H4z" />
+                  <path d="M16 8.5a5 5 0 010 7" />
+                </svg>
+              </button>
+            </div>
+
+            <p id="dv2-prompt" class="dv2-prompt">—</p>
+
+            <div id="dv2-context" class="dv2-context" hidden>
+              <span id="dv2-pronoun" class="dv2-chip">—</span>
+              <span id="dv2-tense" class="dv2-chip dv2-chip--tense">—</span>
+            </div>
+
+            <div id="dv2-options" class="dv2-options" role="group" aria-label="Atbilžu varianti">
+            </div>
+
+            <div id="dv2-builder" class="dv2-builder" hidden>
+              <p class="dv2-builder__preview" aria-live="polite">
+                <span id="dv2-build-stem" class="dv2-slot" data-empty="true">sakne</span>
+                <span id="dv2-build-ending" class="dv2-slot dv2-slot--ending" data-empty="true"
+                  >galotne</span
+                >
+              </p>
+              <div
+                id="dv2-stem-options"
+                class="dv2-chip-row"
+                role="group"
+                aria-label="Saknes varianti"
+              ></div>
+              <div
+                id="dv2-ending-options"
+                class="dv2-chip-row"
+                role="group"
+                aria-label="Galotnes varianti"
+              ></div>
+              <button id="dv2-check" class="dv2-primary" type="button" disabled>Pārbaudīt</button>
+            </div>
+
+            <p class="dv2-hint">
+              <span class="dv2-hint__touch">Velc pa kreisi — tālāk · pa labi — noklausies</span>
+              <span class="dv2-hint__keys">Taustiņi 1–4 izvēlas atbildi · Enter turpina</span>
+            </p>
+          </article>
+
+          <aside
+            id="dv2-feedback"
+            class="dv2-feedback"
+            aria-live="polite"
+            aria-atomic="true"
+            hidden
+          >
+            <div class="dv2-feedback__body">
+              <h2 id="dv2-feedback-title" class="dv2-feedback__title">Pareizi!</h2>
+              <p id="dv2-feedback-text" class="dv2-feedback__text">—</p>
+            </div>
+            <button id="dv2-next" class="dv2-primary" type="button">Tālāk</button>
+          </aside>
+        </section>
+
+        <section
+          class="dv2-screen dv2-summary"
+          data-screen="summary"
+          aria-labelledby="dv2-summary-title"
+          hidden
+        >
+          <header class="dv2-hero">
+            <h2 id="dv2-summary-title" class="dv2-title">Raunds pabeigts</h2>
+            <p id="dv2-summary-message" class="dv2-lead">—</p>
+          </header>
+
+          <div class="dv2-ring" role="img" aria-labelledby="dv2-summary-accuracy-label">
+            <strong id="dv2-summary-accuracy">0%</strong>
+            <span id="dv2-summary-accuracy-label">precizitāte</span>
+          </div>
+
+          <dl class="dv2-summary-grid">
+            <div>
+              <dt>Rezultāts</dt>
+              <dd id="dv2-summary-score">0/0</dd>
+            </div>
+            <div>
+              <dt>Nopelnīts</dt>
+              <dd id="dv2-summary-xp">0 XP</dd>
+            </div>
+            <div>
+              <dt>Labākā sērija</dt>
+              <dd id="dv2-summary-streak">0</dd>
+            </div>
+            <div>
+              <dt>Apgūti kopā</dt>
+              <dd id="dv2-summary-mastered">0</dd>
+            </div>
+          </dl>
+
+          <section class="dv2-panel" aria-labelledby="dv2-review-heading">
+            <h3 id="dv2-review-heading" class="dv2-panel__title">Šī raunda vārdi</h3>
+            <ul id="dv2-review" class="dv2-review"></ul>
+          </section>
+
+          <div class="dv2-cta">
+            <button id="dv2-replay" class="dv2-primary" type="button">Vēl viens raunds</button>
+            <button id="dv2-home" class="dv2-ghost" type="button">Uz sākumu</button>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="dp-footer" data-site-footer></footer>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
+      crossorigin="anonymous"
+    ></script>
+    <script defer src="data/words.offline.js"></script>
+    <script type="module" src="theme.js"></script>
+    <script type="module" src="scripts/nav.js"></script>
+    <script type="module" src="scripts/page-init.js"></script>
+    <script type="module" src="src/games/darbibas-vardi-v2/index.js"></script>
+  </body>
+</html>

--- a/e2e/game-pages.spec.js
+++ b/e2e/game-pages.spec.js
@@ -56,6 +56,50 @@ test('darbibas vardi keeps columns parallel on mobile', async ({ page }) => {
   expect(Math.abs((trBox?.x || 0) - (lvBox?.x || 0))).toBeGreaterThan(20);
 });
 
+test('darbibas vardi v2 plays an adaptive round', async ({ page }) => {
+  await page.goto('/darbibas-vardi-v2.html');
+
+  await expect(page.getByRole('heading', { name: 'Darbības Vārdi V2' })).toBeVisible();
+  const start = page.locator('#dv2-start');
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  await expect(page.locator('[data-screen="play"]')).toBeVisible();
+  // A fresh deck has no mastery records, so every verb starts on the meaning stage.
+  await expect(page.locator('#dv2-stage-label')).toHaveText('Nozīme');
+  await expect(page.locator('#dv2-progress-text')).toHaveText(/^0\/\d+$/);
+
+  const options = page.locator('#dv2-options .dv2-option');
+  await expect(options).toHaveCount(4);
+  await options.first().click();
+
+  const feedback = page.locator('#dv2-feedback');
+  await expect(feedback).toBeVisible();
+  await expect(page.locator('#dv2-progress-text')).toHaveText(/^1\/\d+$/);
+
+  await page.locator('#dv2-next').click();
+  await expect(feedback).toBeHidden();
+  await expect(options.first()).toBeEnabled();
+
+  await page.locator('#dv2-quit').click();
+  await expect(page.locator('[data-screen="start"]')).toBeVisible();
+});
+
+test('darbibas vardi v2 fits a phone viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/darbibas-vardi-v2.html');
+
+  const start = page.locator('#dv2-start');
+  await expect(start).toBeEnabled();
+  await start.click();
+  await expect(page.locator('#dv2-options .dv2-option').first()).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(1);
+});
+
 test('english-latvian arcade page loads and starts a round', async ({ page }) => {
   await page.goto('/english-latvian-arcade.html');
 

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -3,6 +3,11 @@ import { test, expect } from '@playwright/test';
 const homepagePreviewCards = [
   { title: 'Darbības Vārdi', preview: 'verbs_preview.png', href: 'darbibas-vards.html' },
   {
+    title: 'Darbības Vārdi V2',
+    preview: 'verbs_preview.png',
+    href: 'darbibas-vardi-v2.html',
+  },
+  {
     title: 'Nākt ar priedēkļiem',
     preview: 'verbs_preview.png',
     href: 'prefixed-coming-verbs.html',
@@ -141,27 +146,27 @@ test('form factory loads data and checks choice and build modes', async ({ page 
   await page.goto('/form-factory.html');
 
   await expect(page.getByRole('heading', { name: 'Form Factory' })).toBeVisible();
-  await expect(page.locator('#ff-lemma')).not.toHaveText('—');
-  await expect(page.locator('#ff-choices button')).toHaveCount(4);
+  await expect(page.locator('#fx-lemma')).not.toHaveText('—');
+  await expect(page.locator('#fx-choices button')).toHaveCount(4);
 
   const initialState = await page.evaluate(() => JSON.parse(window.render_game_to_text()));
   await page
-    .locator('#ff-choices')
+    .locator('#fx-choices')
     .getByRole('button', { name: initialState.prompt.answer, exact: true })
     .click();
-  await expect(page.locator('#ff-feedback')).toContainText('Pareizi!');
-  await expect(page.locator('#ff-score')).toHaveText('1');
+  await expect(page.locator('#fx-feedback')).toContainText('Pareizi!');
+  await expect(page.locator('#fx-score')).toHaveText('1');
 
-  await page.locator('#ff-next').click();
-  await page.locator('label[for="ff-mode-build"]').click();
+  await page.locator('#fx-next').click();
+  await page.locator('label[for="fx-mode-build"]').click();
   const buildState = await page.evaluate(() => JSON.parse(window.render_game_to_text()));
   const ending = buildState.prompt.answer.match(/dam(?:ies|ās|as|a|i|s)$/)?.[0] || '';
   await page
-    .locator('#ff-endings')
+    .locator('#fx-endings')
     .getByRole('button', { name: `-${ending}`, exact: true })
     .click();
-  await page.locator('#ff-check-build').click();
-  await expect(page.locator('#ff-feedback')).toContainText('Pareizi!');
+  await page.locator('#fx-check-build').click();
+  await expect(page.locator('#fx-feedback')).toContainText('Pareizi!');
 });
 
 test('form factory v2 starts a cloze round and checks an answer', async ({ page }) => {

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -47,6 +47,17 @@ const games = [
     category: 'verbs',
   },
   {
+    title: 'Darbības Vārdi V2',
+    href: 'darbibas-vardi-v2.html',
+    icon: '🧠',
+    desc: 'Adaptive Latvian verb practice from meaning to conjugated forms and assembly.',
+    tag: 'Adaptive',
+    meta: ['Focus: verbs', '5–10 min', 'B level'],
+    accent: '#4f46e5',
+    art: 'linear-gradient(135deg, rgba(79, 70, 229, 0.28), rgba(217, 119, 6, 0.2)), url("assets/previews/verbs_preview.png")',
+    category: 'verbs',
+  },
+  {
     title: 'Nākt ar priedēkļiem',
     href: 'prefixed-coming-verbs.html',
     icon: '↗',

--- a/scripts/nav-config.js
+++ b/scripts/nav-config.js
@@ -10,6 +10,7 @@
 export const NAV_ITEMS = [
   { href: 'index.html', label: 'Home' },
   { href: 'darbibas-vards.html', label: 'Darbības Vārds' },
+  { href: 'darbibas-vardi-v2.html', label: 'Darbības Vārdi V2' },
   { href: 'prefixed-coming-verbs.html', label: 'Nākt ar priedēkļiem' },
   { href: 'similar-word-groups.html', label: 'Līdzīgo formu treniņš' },
   { href: 'conjugation-sprint.html', label: 'Conjugation Sprint' },

--- a/src/games/darbibas-vardi-v2/index.js
+++ b/src/games/darbibas-vardi-v2/index.js
@@ -1,0 +1,679 @@
+/**
+ * Darbības Vārdi V2 — screen flow, input handling, and persistence.
+ *
+ * Start -> play -> summary. Mastery records decide which ladder stage each verb
+ * gets, and every answer is written back to storage so progress survives reloads.
+ */
+import { announceLive } from '../../lib/aria.js';
+import { hideLoading, showLoading } from '../../lib/loading.js';
+import { showReward } from '../../lib/reward.js';
+import { clearGameProgress, readGameProgress, writeGameProgress } from '../../lib/storage.js';
+import { loadWords } from '../../lib/words-data.js';
+import {
+  MAX_BOX,
+  ROUND_SIZE,
+  STAGES,
+  STAGE_LABELS,
+  applyResult,
+  buildExplanation,
+  buildRound,
+  buildTask,
+  calculateAccuracy,
+  computeDailyStreak,
+  describeDeck,
+  isCorrectAssembly,
+  isCorrectChoice,
+  normalizeRecords,
+  normalizeVerbs,
+  stageForVerb,
+  xpForAnswer,
+} from './logic.js';
+
+const GAME_ID = 'darbibas-vardi-v2';
+const SWIPE_THRESHOLD = 60;
+const OPTION_KEYS = ['1', '2', '3', '4'];
+
+function toCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function getElements(root) {
+  const q = (selector) => root.querySelector(selector);
+  return {
+    root,
+    screens: {
+      start: q('[data-screen="start"]'),
+      play: q('[data-screen="play"]'),
+      summary: q('[data-screen="summary"]'),
+    },
+    error: q('#dv2-error'),
+    live: q('#dv2-live'),
+    xp: q('#dv2-xp'),
+    dailyStreak: q('#dv2-daily-streak'),
+    bestStreak: q('#dv2-best-streak'),
+    dueCount: q('#dv2-due-count'),
+    learningCount: q('#dv2-learning-count'),
+    masteredCount: q('#dv2-mastered-count'),
+    freshCount: q('#dv2-fresh-count'),
+    masteryBar: q('#dv2-mastery-bar'),
+    deckNote: q('#dv2-deck-note'),
+    languageButtons: Array.from(root.querySelectorAll('[data-language]')),
+    speechToggle: q('#dv2-speech-toggle'),
+    hapticsToggle: q('#dv2-haptics-toggle'),
+    start: q('#dv2-start'),
+    reset: q('#dv2-reset'),
+    quit: q('#dv2-quit'),
+    stageLabel: q('#dv2-stage-label'),
+    progressText: q('#dv2-progress-text'),
+    progress: q('#dv2-progress'),
+    progressBar: q('#dv2-progress-bar'),
+    roundXp: q('#dv2-round-xp'),
+    streak: q('#dv2-streak'),
+    card: q('#dv2-card'),
+    promptLabel: q('#dv2-prompt-label'),
+    prompt: q('#dv2-prompt'),
+    speak: q('#dv2-speak'),
+    context: q('#dv2-context'),
+    pronoun: q('#dv2-pronoun'),
+    tense: q('#dv2-tense'),
+    options: q('#dv2-options'),
+    builder: q('#dv2-builder'),
+    buildStem: q('#dv2-build-stem'),
+    buildEnding: q('#dv2-build-ending'),
+    stemOptions: q('#dv2-stem-options'),
+    endingOptions: q('#dv2-ending-options'),
+    check: q('#dv2-check'),
+    keysHint: q('.dv2-hint__keys'),
+    feedback: q('#dv2-feedback'),
+    feedbackTitle: q('#dv2-feedback-title'),
+    feedbackText: q('#dv2-feedback-text'),
+    next: q('#dv2-next'),
+    ring: q('.dv2-ring'),
+    summaryMessage: q('#dv2-summary-message'),
+    summaryAccuracy: q('#dv2-summary-accuracy'),
+    summaryScore: q('#dv2-summary-score'),
+    summaryXp: q('#dv2-summary-xp'),
+    summaryStreak: q('#dv2-summary-streak'),
+    summaryMastered: q('#dv2-summary-mastered'),
+    review: q('#dv2-review'),
+    replay: q('#dv2-replay'),
+    home: q('#dv2-home'),
+  };
+}
+
+function defaultProgress() {
+  return {
+    records: {},
+    xp: 0,
+    bestStreak: 0,
+    dailyStreak: 0,
+    roundsPlayed: 0,
+    lastPlayedISO: '',
+    language: 'en',
+    speech: false,
+    haptics: true,
+  };
+}
+
+function readStoredProgress() {
+  try {
+    const saved = readGameProgress(GAME_ID, {});
+    return {
+      records: normalizeRecords(saved.records),
+      xp: toCount(saved.xp),
+      bestStreak: toCount(saved.bestStreak),
+      dailyStreak: toCount(saved.dailyStreak),
+      roundsPlayed: toCount(saved.roundsPlayed),
+      lastPlayedISO: typeof saved.lastPlayedISO === 'string' ? saved.lastPlayedISO : '',
+      language: saved.language === 'ru' ? 'ru' : 'en',
+      speech: saved.speech === true,
+      haptics: saved.haptics !== false,
+    };
+  } catch (err) {
+    console.warn('Unable to read Darbības Vārdi V2 progress', err);
+    return defaultProgress();
+  }
+}
+
+function persist(state) {
+  try {
+    writeGameProgress(GAME_ID, {
+      records: state.records,
+      xp: state.xp,
+      bestStreak: state.bestStreak,
+      dailyStreak: state.dailyStreak,
+      roundsPlayed: state.roundsPlayed,
+      lastPlayedISO: state.lastPlayedISO,
+      language: state.language,
+      speech: state.speech,
+      haptics: state.haptics,
+    });
+  } catch (err) {
+    console.warn('Unable to persist Darbības Vārdi V2 progress', err);
+  }
+}
+
+function initGame(root) {
+  const els = getElements(root);
+  const stored = readStoredProgress();
+  const state = {
+    ...stored,
+    screen: 'start',
+    verbs: [],
+    queue: [],
+    retried: new Set(),
+    reviewed: new Map(),
+    task: null,
+    total: 0,
+    answered: 0,
+    correct: 0,
+    streak: 0,
+    roundBestStreak: 0,
+    roundXp: 0,
+    locked: true,
+    build: { stem: null, ending: null },
+  };
+
+  bindControls(els, state);
+  renderSettings(els, state);
+  renderStart(els, state);
+  showScreen(els, state, 'start');
+
+  showLoading('Ielādē darbības vārdus...');
+  loadWords({ cache: 'force-cache' })
+    .then(({ items }) => {
+      state.verbs = normalizeVerbs(items);
+      if (!state.verbs.length) throw new Error('Verb dataset is empty.');
+      renderStart(els, state);
+      els.start.disabled = false;
+    })
+    .catch((err) => {
+      console.error(err);
+      showError(els, 'Neizdevās ielādēt vārdu krājumu. Pārbaudi savienojumu un mēģini vēlreiz.');
+      els.start.disabled = true;
+    })
+    .finally(() => hideLoading());
+}
+
+function showError(els, message) {
+  if (!els.error) return;
+  els.error.textContent = message;
+  els.error.hidden = false;
+}
+
+function showScreen(els, state, screen) {
+  state.screen = screen;
+  Object.entries(els.screens).forEach(([name, node]) => {
+    if (node) node.hidden = name !== screen;
+  });
+  if (screen !== 'play') hideFeedback(els);
+}
+
+/* ---------- Settings & start screen ---------- */
+
+function renderSettings(els, state) {
+  els.languageButtons.forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset.language === state.language));
+  });
+  setSwitch(els.speechToggle, state.speech);
+  setSwitch(els.hapticsToggle, state.haptics);
+}
+
+function setSwitch(button, on) {
+  if (!button) return;
+  button.setAttribute('aria-pressed', String(on));
+  const text = button.querySelector('.dv2-switch__text');
+  if (text) text.textContent = on ? 'Ieslēgta' : 'Izslēgta';
+}
+
+function renderStart(els, state) {
+  const summary = describeDeck(state.verbs, state.records);
+  els.xp.textContent = String(state.xp);
+  els.dailyStreak.textContent = String(state.dailyStreak);
+  els.bestStreak.textContent = String(state.bestStreak);
+  els.dueCount.textContent = String(summary.due);
+  els.learningCount.textContent = String(summary.learning);
+  els.masteredCount.textContent = String(summary.mastered);
+  els.freshCount.textContent = String(summary.fresh);
+
+  const mastery = summary.total ? Math.round((summary.mastered / summary.total) * 100) : 0;
+  els.masteryBar.style.width = `${mastery}%`;
+
+  if (!summary.total) {
+    els.deckNote.textContent = 'Ielādē vārdu krājumu…';
+  } else if (summary.due) {
+    els.deckNote.textContent = `${summary.total} vārdi kavā · ${summary.due} gaida atkārtošanu.`;
+  } else {
+    els.deckNote.textContent = `${summary.total} vārdi kavā · apgūti ${mastery}%.`;
+  }
+}
+
+/* ---------- Round flow ---------- */
+
+function startRound(els, state) {
+  const round = buildRound(state.verbs, state.records, { size: ROUND_SIZE });
+  if (!round.length) {
+    showError(els, 'Kavā nav neviena darbības vārda.');
+    return;
+  }
+  state.queue = round.slice();
+  state.retried = new Set();
+  state.reviewed = new Map();
+  state.total = round.length;
+  state.answered = 0;
+  state.correct = 0;
+  state.streak = 0;
+  state.roundBestStreak = 0;
+  state.roundXp = 0;
+  showScreen(els, state, 'play');
+  nextTask(els, state);
+}
+
+function nextTask(els, state) {
+  hideFeedback(els);
+  while (state.queue.length) {
+    const verb = state.queue.shift();
+    const stage = stageForVerb(verb, state.records[verb.id]);
+    const task = buildTask(verb, state.verbs, { stage, language: state.language });
+    if (task) {
+      state.task = task;
+      state.build = { stem: null, ending: null };
+      state.locked = false;
+      renderTask(els, state);
+      return;
+    }
+    // A verb the dataset cannot turn into any task never re-enters the round.
+    state.total = Math.max(1, state.total - 1);
+  }
+  finishRound(els, state);
+}
+
+function renderTask(els, state) {
+  const task = state.task;
+  els.stageLabel.textContent = STAGE_LABELS[task.stage];
+  els.promptLabel.textContent = task.promptLabel;
+  els.prompt.textContent = task.prompt;
+  els.speak.hidden = !state.speech;
+
+  const hasContext = Boolean(task.pronoun || task.tenseLabel);
+  els.context.hidden = !hasContext;
+  els.pronoun.textContent = task.pronoun || '';
+  els.tense.textContent = task.tenseLabel || '';
+
+  renderProgress(els, state);
+  if (task.stage === STAGES.BUILD) renderBuilder(els, state, task);
+  else renderOptions(els, state, task);
+  els.keysHint.textContent =
+    task.stage === STAGES.BUILD
+      ? 'Tab un atstarpe izvēlas daļas · Enter turpina'
+      : 'Taustiņi 1–4 izvēlas atbildi · Enter turpina';
+
+  announceLive(els.live, `${task.promptLabel} ${task.prompt}`);
+  if (state.speech) speak(state, task.speakText);
+}
+
+function renderProgress(els, state) {
+  const done = state.answered;
+  els.progressText.textContent = `${done}/${state.total}`;
+  const percent = state.total ? Math.round((done / state.total) * 100) : 0;
+  els.progressBar.style.width = `${percent}%`;
+  els.progress.setAttribute('aria-valuenow', String(percent));
+  els.roundXp.textContent = String(state.roundXp);
+  els.streak.textContent = String(state.streak);
+}
+
+function renderOptions(els, state, task) {
+  els.builder.hidden = true;
+  els.options.hidden = false;
+  els.options.replaceChildren();
+  task.options.forEach((option, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'dv2-option';
+    button.dataset.value = option;
+
+    const key = document.createElement('span');
+    key.className = 'dv2-option__key';
+    key.setAttribute('aria-hidden', 'true');
+    key.textContent = OPTION_KEYS[index] || String(index + 1);
+
+    const text = document.createElement('span');
+    text.className = 'dv2-option__text';
+    text.textContent = option;
+
+    button.append(key, text);
+    button.addEventListener('click', () => submitChoice(els, state, option));
+    els.options.append(button);
+  });
+  const first = els.options.querySelector('.dv2-option');
+  if (first) first.focus({ preventScroll: true });
+}
+
+function renderBuilder(els, state, task) {
+  els.options.hidden = true;
+  els.options.replaceChildren();
+  els.builder.hidden = false;
+  els.check.disabled = true;
+  setSlot(els.buildStem, null, 'sakne');
+  setSlot(els.buildEnding, null, 'galotne');
+
+  renderParts(els.stemOptions, task.stemOptions, (value) => selectPart(els, state, 'stem', value));
+  renderParts(els.endingOptions, task.endingOptions, (value) =>
+    selectPart(els, state, 'ending', value),
+  );
+
+  // A single stem candidate carries no choice, so pre-select it.
+  if (task.stemOptions.length === 1) selectPart(els, state, 'stem', task.stemOptions[0]);
+  const first = els.stemOptions.querySelector('.dv2-part');
+  if (first) first.focus({ preventScroll: true });
+}
+
+function renderParts(container, values, onSelect) {
+  container.replaceChildren();
+  values.forEach((value) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'dv2-part';
+    button.dataset.value = value;
+    button.setAttribute('aria-pressed', 'false');
+    button.textContent = value;
+    button.addEventListener('click', () => onSelect(value));
+    container.append(button);
+  });
+}
+
+function selectPart(els, state, slot, value) {
+  if (state.locked) return;
+  state.build[slot] = value;
+  const container = slot === 'stem' ? els.stemOptions : els.endingOptions;
+  container.querySelectorAll('.dv2-part').forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset.value === value));
+  });
+  const isStem = slot === 'stem';
+  setSlot(isStem ? els.buildStem : els.buildEnding, value, isStem ? 'sakne' : 'galotne');
+  els.check.disabled = !(state.build.stem && state.build.ending);
+}
+
+function setSlot(node, value, placeholder) {
+  node.textContent = value || placeholder;
+  node.dataset.empty = value ? 'false' : 'true';
+}
+
+function submitChoice(els, state, value) {
+  if (state.locked || !state.task) return;
+  const correct = isCorrectChoice(value, state.task);
+  els.options.querySelectorAll('.dv2-option').forEach((button) => {
+    button.disabled = true;
+    const isAnswer = isCorrectChoice(button.dataset.value, state.task);
+    if (isAnswer) button.classList.add('dv2-option--correct');
+    else if (button.dataset.value === value) button.classList.add('dv2-option--wrong');
+  });
+  resolveAnswer(els, state, correct);
+}
+
+function submitAssembly(els, state) {
+  if (state.locked || !state.task) return;
+  const { stem, ending } = state.build;
+  if (!stem || !ending) return;
+  const correct = isCorrectAssembly(stem, ending, state.task);
+  els.builder.querySelectorAll('.dv2-part').forEach((button) => {
+    button.disabled = true;
+  });
+  els.check.disabled = true;
+  if (!correct) {
+    setSlot(els.buildStem, state.task.stem, 'sakne');
+    setSlot(els.buildEnding, state.task.ending, 'galotne');
+  }
+  resolveAnswer(els, state, correct);
+}
+
+function resolveAnswer(els, state, correct) {
+  const task = state.task;
+  state.locked = true;
+  state.answered += 1;
+
+  if (correct) {
+    state.correct += 1;
+    state.streak += 1;
+    state.roundBestStreak = Math.max(state.roundBestStreak, state.streak);
+    state.bestStreak = Math.max(state.bestStreak, state.streak);
+    const gained = xpForAnswer(task.stage, state.streak - 1);
+    state.roundXp += gained;
+    state.xp += gained;
+  } else {
+    state.streak = 0;
+    // Give a missed verb one more shot before the round ends.
+    if (!state.retried.has(task.verbId)) {
+      const verb = state.verbs.find((entry) => entry.id === task.verbId);
+      if (verb) {
+        state.retried.add(task.verbId);
+        state.queue.push(verb);
+        state.total += 1;
+      }
+    }
+  }
+
+  const before = state.records[task.verbId];
+  const after = applyResult(before, correct);
+  state.records[task.verbId] = after;
+  state.reviewed.set(task.verbId, {
+    lv: task.lv,
+    fromBox: before?.box ?? 0,
+    toBox: after.box,
+  });
+
+  vibrate(state, correct ? 18 : [12, 60, 12]);
+  persist(state);
+  renderProgress(els, state);
+  showFeedback(els, state, correct);
+}
+
+function showFeedback(els, state, correct) {
+  const message = buildExplanation(state.task, correct);
+  const title = correct ? 'Pareizi!' : 'Vēl ne gluži';
+  els.feedback.dataset.result = correct ? 'correct' : 'wrong';
+  els.feedbackTitle.textContent = title;
+  els.feedbackText.textContent = message;
+  els.feedback.hidden = false;
+  els.next.textContent = state.queue.length ? 'Tālāk' : 'Pabeigt';
+  els.next.focus({ preventScroll: true });
+  announceLive(els.live, `${title} ${message}`);
+}
+
+function hideFeedback(els) {
+  els.feedback.hidden = true;
+  delete els.feedback.dataset.result;
+}
+
+function finishRound(els, state) {
+  state.roundsPlayed += 1;
+  state.dailyStreak = computeDailyStreak(state.lastPlayedISO, state.dailyStreak);
+  state.lastPlayedISO = new Date().toISOString();
+  persist(state);
+  renderSummary(els, state);
+  renderStart(els, state);
+  showScreen(els, state, 'summary');
+
+  const accuracy = calculateAccuracy(state.correct, state.answered);
+  showReward({
+    title: accuracy >= 80 ? 'Lielisks raunds!' : 'Raunds pabeigts',
+    detail: `Precizitāte ${accuracy}%`,
+    tone: accuracy >= 80 ? 'success' : 'accent',
+    points: state.roundXp,
+    pointsLabel: 'XP',
+  });
+}
+
+function renderSummary(els, state) {
+  const accuracy = calculateAccuracy(state.correct, state.answered);
+  const summary = describeDeck(state.verbs, state.records);
+  els.ring.style.setProperty('--dv2-accuracy', String(accuracy));
+  els.summaryAccuracy.textContent = `${accuracy}%`;
+  els.summaryScore.textContent = `${state.correct}/${state.answered}`;
+  els.summaryXp.textContent = `${state.roundXp} XP`;
+  els.summaryStreak.textContent = String(state.roundBestStreak);
+  els.summaryMastered.textContent = `${summary.mastered}/${summary.total}`;
+  els.summaryMessage.textContent =
+    summary.due > 0
+      ? `${summary.due} vārdi jau gaida nākamo atkārtojumu.`
+      : 'Viss atkārtots. Nāc atpakaļ rīt, lai noturētu sēriju.';
+
+  els.review.replaceChildren();
+  state.reviewed.forEach((entry) => {
+    const item = document.createElement('li');
+
+    const word = document.createElement('span');
+    word.className = 'dv2-review__word';
+    word.textContent = entry.lv;
+
+    const badge = document.createElement('span');
+    badge.className = 'dv2-review__box';
+    badge.dataset.direction = entry.toBox > entry.fromBox ? 'up' : 'down';
+    badge.textContent =
+      entry.toBox > entry.fromBox
+        ? `${entry.toBox}/${MAX_BOX} līmenis ↑`
+        : `${entry.toBox}/${MAX_BOX} līmenis ↓`;
+
+    item.append(word, badge);
+    els.review.append(item);
+  });
+}
+
+/* ---------- Output channels ---------- */
+
+function speak(state, text) {
+  if (!state.speech || !text) return;
+  const synth = window.speechSynthesis;
+  if (!synth) return;
+  try {
+    synth.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'lv-LV';
+    const voice = synth.getVoices().find((entry) => entry.lang?.toLowerCase().startsWith('lv'));
+    if (voice) utterance.voice = voice;
+    synth.speak(utterance);
+  } catch (err) {
+    console.warn('Speech synthesis unavailable', err);
+  }
+}
+
+function vibrate(state, pattern) {
+  if (!state.haptics) return;
+  if (typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') return;
+  try {
+    navigator.vibrate(pattern);
+  } catch (err) {
+    console.warn('Vibration unavailable', err);
+  }
+}
+
+/* ---------- Input wiring ---------- */
+
+function bindControls(els, state) {
+  els.start.disabled = true;
+  els.start.addEventListener('click', () => startRound(els, state));
+  els.replay.addEventListener('click', () => startRound(els, state));
+  els.home.addEventListener('click', () => showScreen(els, state, 'start'));
+  els.quit.addEventListener('click', () => quitRound(els, state));
+  els.next.addEventListener('click', () => nextTask(els, state));
+  els.check.addEventListener('click', () => submitAssembly(els, state));
+  els.speak.addEventListener('click', () => speak(state, state.task?.speakText));
+
+  els.languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      state.language = button.dataset.language === 'ru' ? 'ru' : 'en';
+      renderSettings(els, state);
+      persist(state);
+    });
+  });
+
+  els.speechToggle.addEventListener('click', () => {
+    state.speech = !state.speech;
+    renderSettings(els, state);
+    persist(state);
+  });
+
+  els.hapticsToggle.addEventListener('click', () => {
+    state.haptics = !state.haptics;
+    renderSettings(els, state);
+    persist(state);
+  });
+
+  els.reset.addEventListener('click', () => resetProgress(els, state));
+
+  bindSwipe(els, state);
+  document.addEventListener('keydown', (event) => handleKeydown(els, state, event));
+}
+
+function quitRound(els, state) {
+  state.queue = [];
+  state.task = null;
+  renderStart(els, state);
+  showScreen(els, state, 'start');
+}
+
+function resetProgress(els, state) {
+  if (!window.confirm('Notīrīt visu saglabāto progresu?')) return;
+  clearGameProgress(GAME_ID);
+  Object.assign(state, defaultProgress());
+  renderSettings(els, state);
+  renderStart(els, state);
+  announceLive(els.live, 'Progress notīrīts.');
+}
+
+function bindSwipe(els, state) {
+  let startX = 0;
+  let startY = 0;
+  let tracking = false;
+
+  els.card.addEventListener('pointerdown', (event) => {
+    if (event.pointerType === 'mouse') return;
+    tracking = true;
+    startX = event.clientX;
+    startY = event.clientY;
+  });
+
+  els.card.addEventListener('pointerup', (event) => {
+    if (!tracking) return;
+    tracking = false;
+    const deltaX = event.clientX - startX;
+    const deltaY = event.clientY - startY;
+    if (Math.abs(deltaX) < SWIPE_THRESHOLD || Math.abs(deltaX) < Math.abs(deltaY)) return;
+    if (deltaX < 0 && state.locked) nextTask(els, state);
+    else if (deltaX > 0) speak(state, state.task?.speakText);
+  });
+
+  els.card.addEventListener('pointercancel', () => {
+    tracking = false;
+  });
+}
+
+function handleKeydown(els, state, event) {
+  if (state.screen !== 'play' || event.metaKey || event.ctrlKey || event.altKey) return;
+
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    quitRound(els, state);
+    return;
+  }
+
+  if (state.locked) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      nextTask(els, state);
+    }
+    return;
+  }
+
+  const index = OPTION_KEYS.indexOf(event.key);
+  if (index === -1) return;
+  const buttons = Array.from(els.options.querySelectorAll('.dv2-option'));
+  const target = buttons[index];
+  if (!target) return;
+  event.preventDefault();
+  target.click();
+}
+
+const root = document.querySelector('[data-darbibas-vardi-v2]');
+if (root) initGame(root);

--- a/src/games/darbibas-vardi-v2/logic.js
+++ b/src/games/darbibas-vardi-v2/logic.js
@@ -1,0 +1,565 @@
+/**
+ * Darbības Vārdi V2 — pure game logic.
+ *
+ * Drives a per-verb Leitner ladder over the shared verb dataset: box 0-1 trains
+ * meaning, box 2 trains conjugated forms, box 3+ trains assembling a form from
+ * stem + ending. Every export is DOM-free so rounds stay deterministic under a
+ * seeded rng.
+ */
+import { sanitizeText } from '../../lib/sanitize.js';
+import { clamp, pickRandom, shuffle } from '../../lib/utils.js';
+
+export const STAGES = { MEANING: 'meaning', FORM: 'form', BUILD: 'build' };
+
+export const STAGE_LABELS = {
+  [STAGES.MEANING]: 'Nozīme',
+  [STAGES.FORM]: 'Forma',
+  [STAGES.BUILD]: 'Būve',
+};
+
+export const MAX_BOX = 4;
+export const ROUND_SIZE = 10;
+export const OPTION_COUNT = 4;
+
+// Without a cap the 300+ unseen verbs would crowd out reviews and the ladder
+// would never climb past the meaning stage.
+export const MAX_NEW_PER_ROUND = 4;
+
+export const PERSONS = [
+  { key: '1s', pronoun: 'es' },
+  { key: '2s', pronoun: 'tu' },
+  { key: '3s', pronoun: 'viņš / viņa' },
+  { key: '1p', pronoun: 'mēs' },
+  { key: '2p', pronoun: 'jūs' },
+  { key: '3p', pronoun: 'viņi / viņas' },
+];
+
+export const TENSES = [
+  { key: 'present', label: 'tagadne' },
+  { key: 'past', label: 'pagātne' },
+  { key: 'future', label: 'nākotne' },
+];
+
+const MINUTE = 60 * 1000;
+const DAY = 24 * 60 * MINUTE;
+
+// Leitner intervals per box; box 0 stays due so a miss returns within the same
+// session, and the first two steps are short enough that a verb can climb from
+// meaning to build in one sitting.
+const BOX_INTERVALS_MS = [0, 2 * MINUTE, 8 * MINUTE, DAY, 4 * DAY];
+
+const XP_BY_STAGE = { [STAGES.MEANING]: 10, [STAGES.FORM]: 15, [STAGES.BUILD]: 20 };
+const STREAK_BONUS_CAP = 5;
+
+// A shorter stem would make the build stage guessable from the chip alone.
+const MIN_STEM_LENGTH = 2;
+
+/**
+ * Normalise text for comparison: strips control chars, collapses whitespace,
+ * and lowercases with Latvian collation so diacritics stay intact.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeAnswer(value) {
+  return sanitizeText(value).normalize('NFC').replace(/\s+/g, ' ').toLocaleLowerCase('lv-LV');
+}
+
+/**
+ * Convert raw dataset rows into verbs with a cleaned conjugation table.
+ * Rows without a Latvian lemma or any translation are dropped; duplicates keep
+ * the first occurrence.
+ * @param {unknown} items
+ * @returns {Array<{id: string, lv: string, en: string, ru: string, conj: object}>}
+ */
+export function normalizeVerbs(items) {
+  const source = Array.isArray(items) ? items : [];
+  const seen = new Set();
+  const verbs = [];
+  source.forEach((item) => {
+    if (!item || typeof item !== 'object') return;
+    const lv = sanitizeText(item.lv);
+    const en = sanitizeText(item.en);
+    const ru = sanitizeText(item.ru);
+    if (!lv || (!en && !ru)) return;
+    const id = normalizeAnswer(lv);
+    if (seen.has(id)) return;
+    seen.add(id);
+    verbs.push({ id, lv, en, ru, conj: normalizeConjugation(item.conj) });
+  });
+  return verbs;
+}
+
+function normalizeConjugation(conj) {
+  if (!conj || typeof conj !== 'object') return {};
+  const table = {};
+  TENSES.forEach(({ key }) => {
+    const source = conj[key];
+    if (!source || typeof source !== 'object') return;
+    const forms = {};
+    PERSONS.forEach(({ key: person }) => {
+      const form = sanitizeText(source[person]);
+      if (form) forms[person] = form;
+    });
+    if (Object.keys(forms).length) table[key] = forms;
+  });
+  return table;
+}
+
+/**
+ * Flatten a verb's conjugation table into {tense, person, form} triples.
+ * @param {object} verb
+ * @returns {Array<{tense: string, person: string, form: string}>}
+ */
+export function listForms(verb) {
+  const table = verb?.conj || {};
+  const forms = [];
+  TENSES.forEach(({ key: tense }) => {
+    const row = table[tense];
+    if (!row) return;
+    PERSONS.forEach(({ key: person }) => {
+      if (row[person]) forms.push({ tense, person, form: row[person] });
+    });
+  });
+  return forms;
+}
+
+/**
+ * A verb can only host form/build tasks when it offers enough distinct forms
+ * to fill an option row without repeats.
+ * @param {object} verb
+ * @returns {boolean}
+ */
+export function hasConjugation(verb) {
+  const unique = new Set(listForms(verb).map((entry) => normalizeAnswer(entry.form)));
+  return unique.size >= OPTION_COUNT;
+}
+
+/**
+ * @param {object} verb
+ * @param {'en' | 'ru'} language
+ * @returns {string}
+ */
+export function getTranslation(verb, language = 'en') {
+  if (!verb) return '';
+  return language === 'ru' ? verb.ru || verb.en : verb.en || verb.ru;
+}
+
+export function pronounFor(person) {
+  return PERSONS.find((entry) => entry.key === person)?.pronoun || '';
+}
+
+export function tenseLabel(tense) {
+  return TENSES.find((entry) => entry.key === tense)?.label || '';
+}
+
+export function createRecord() {
+  return { box: 0, dueAt: 0, seen: 0, correct: 0, wrong: 0 };
+}
+
+/**
+ * Coerce persisted mastery data back into a trusted shape; unknown or corrupt
+ * entries collapse to zeroed counters rather than throwing.
+ * @param {unknown} raw
+ * @returns {Record<string, object>} Mastery records keyed by verb id.
+ */
+export function normalizeRecords(raw) {
+  const records = {};
+  if (!raw || typeof raw !== 'object') return records;
+  Object.entries(raw).forEach(([id, value]) => {
+    if (!id || !value || typeof value !== 'object') return;
+    records[id] = {
+      box: clamp(toCount(value.box), 0, MAX_BOX),
+      dueAt: toCount(value.dueAt),
+      seen: toCount(value.seen),
+      correct: toCount(value.correct),
+      wrong: toCount(value.wrong),
+    };
+  });
+  return records;
+}
+
+function toCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+/**
+ * Move a verb up or down the Leitner ladder and reschedule it.
+ * @param {object | undefined} record
+ * @param {boolean} wasCorrect
+ * @param {number} now
+ */
+export function applyResult(record, wasCorrect, now = Date.now()) {
+  const base = record ? { ...createRecord(), ...record } : createRecord();
+  const box = wasCorrect ? clamp(base.box + 1, 0, MAX_BOX) : 0;
+  return {
+    box,
+    dueAt: now + BOX_INTERVALS_MS[box],
+    seen: base.seen + 1,
+    correct: base.correct + (wasCorrect ? 1 : 0),
+    wrong: base.wrong + (wasCorrect ? 0 : 1),
+  };
+}
+
+export function stageForBox(box) {
+  if (box <= 1) return STAGES.MEANING;
+  if (box === 2) return STAGES.FORM;
+  return STAGES.BUILD;
+}
+
+/**
+ * Verbs shipped without a usable conjugation table stay on the meaning stage
+ * no matter how high their box climbs.
+ */
+export function stageForVerb(verb, record) {
+  const stage = stageForBox(record?.box ?? 0);
+  if (stage === STAGES.MEANING) return stage;
+  return hasConjugation(verb) ? stage : STAGES.MEANING;
+}
+
+/**
+ * Order a round as reviews first, then a capped slice of unseen verbs. The cap
+ * keeps the 300+ new words from burying reviews; the top-up keeps the round full
+ * when either pool runs short.
+ * @param {Array<object>} verbs
+ * @param {Record<string, object>} records
+ * @param {{size?: number, now?: number, maxNew?: number, rng?: () => number}} [options]
+ * @returns {Array<object>}
+ */
+export function buildRound(verbs, records = {}, options = {}) {
+  const {
+    size = ROUND_SIZE,
+    now = Date.now(),
+    maxNew = MAX_NEW_PER_ROUND,
+    rng = Math.random,
+  } = options;
+  const pool = Array.isArray(verbs) ? verbs : [];
+  if (!pool.length) return [];
+
+  const due = [];
+  const weak = [];
+  const fresh = [];
+  const resting = [];
+  pool.forEach((verb) => {
+    const record = records[verb.id];
+    if (!record || !record.seen) fresh.push(verb);
+    else if (record.dueAt <= now) due.push(verb);
+    else if (record.wrong > record.correct) weak.push(verb);
+    else resting.push(verb);
+  });
+
+  due.sort((a, b) => compareSchedule(records[a.id], records[b.id]));
+  weak.sort((a, b) => weakness(records[b.id]) - weakness(records[a.id]));
+  // Fillers are not due yet, so lead with the most advanced ones: that is where
+  // the form and build stages live.
+  resting.sort((a, b) => compareMastery(records[a.id], records[b.id]));
+
+  const reviews = [...due, ...weak, ...resting];
+  const shuffledFresh = shuffle(fresh, rng);
+  const newCount = Math.min(Math.max(maxNew, 0), size, shuffledFresh.length);
+  const reviewCount = Math.max(size - newCount, 0);
+  const ordered = [...reviews.slice(0, reviewCount), ...shuffledFresh.slice(0, newCount)];
+  ordered.push(...reviews.slice(reviewCount), ...shuffledFresh.slice(newCount));
+  return ordered.slice(0, Math.max(1, size));
+}
+
+function compareSchedule(a, b) {
+  return a.dueAt - b.dueAt || a.box - b.box;
+}
+
+function compareMastery(a, b) {
+  return b.box - a.box || a.dueAt - b.dueAt;
+}
+
+function weakness(record) {
+  return record.wrong - record.correct;
+}
+
+/**
+ * Summarise deck health for the start screen.
+ * @param {Array<object>} verbs
+ * @param {Record<string, object>} records
+ * @param {number} now
+ */
+export function describeDeck(verbs, records = {}, now = Date.now()) {
+  const summary = { total: 0, fresh: 0, learning: 0, due: 0, mastered: 0 };
+  (Array.isArray(verbs) ? verbs : []).forEach((verb) => {
+    summary.total += 1;
+    const record = records[verb.id];
+    if (!record || !record.seen) {
+      summary.fresh += 1;
+      return;
+    }
+    if (record.box >= MAX_BOX) summary.mastered += 1;
+    else summary.learning += 1;
+    if (record.dueAt <= now) summary.due += 1;
+  });
+  return summary;
+}
+
+/**
+ * Pick a meaning task in either direction; returns null when the pool is too
+ * small to fill unique options.
+ */
+export function buildMeaningTask(verb, pool, options = {}) {
+  const { language = 'en', direction, rng = Math.random } = options;
+  const translation = getTranslation(verb, language);
+  if (!verb?.lv || !translation) return null;
+
+  const mode = direction || (rng() < 0.5 ? 'lv-to-tr' : 'tr-to-lv');
+  const toLatvian = mode === 'tr-to-lv';
+  const answer = toLatvian ? verb.lv : translation;
+  const candidates = (Array.isArray(pool) ? pool : []).filter((entry) => entry.id !== verb.id);
+  const distractors = collectUnique(
+    shuffle(candidates, rng).map((entry) =>
+      toLatvian ? entry.lv : getTranslation(entry, language),
+    ),
+    answer,
+    OPTION_COUNT - 1,
+  );
+  if (distractors.length < OPTION_COUNT - 1) return null;
+
+  return {
+    stage: STAGES.MEANING,
+    verbId: verb.id,
+    direction: mode,
+    promptLabel: toLatvian ? 'Kurš darbības vārds tas ir?' : 'Ko nozīmē šis darbības vārds?',
+    prompt: toLatvian ? translation : verb.lv,
+    pronoun: '',
+    tenseLabel: '',
+    answer,
+    options: shuffle([answer, ...distractors], rng),
+    speakText: verb.lv,
+  };
+}
+
+/**
+ * Ask for one person+tense form and fill the option row with the verb's own
+ * near-miss forms, so the choice cannot be solved by elimination.
+ */
+export function buildFormTask(verb, options = {}) {
+  const { tense, person, rng = Math.random } = options;
+  const forms = listForms(verb);
+  if (!forms.length) return null;
+
+  const scoped = forms.filter(
+    (entry) => (!tense || entry.tense === tense) && (!person || entry.person === person),
+  );
+  const target = pickRandom(scoped.length ? scoped : forms, rng);
+  if (!target) return null;
+
+  const sameTense = forms.filter(
+    (entry) => entry.tense === target.tense && entry.person !== target.person,
+  );
+  const otherTenses = forms.filter((entry) => entry.tense !== target.tense);
+  const distractors = collectUnique(
+    [...shuffle(sameTense, rng), ...shuffle(otherTenses, rng)].map((entry) => entry.form),
+    target.form,
+    OPTION_COUNT - 1,
+  );
+  if (distractors.length < OPTION_COUNT - 1) return null;
+
+  return {
+    stage: STAGES.FORM,
+    verbId: verb.id,
+    tense: target.tense,
+    person: target.person,
+    promptLabel: 'Izvēlies pareizo formu',
+    prompt: verb.lv,
+    pronoun: pronounFor(target.person),
+    tenseLabel: tenseLabel(target.tense),
+    answer: target.form,
+    options: shuffle([target.form, ...distractors], rng),
+    speakText: target.form,
+  };
+}
+
+/**
+ * Derive one stem per tense by trimming the tense's longest common prefix until
+ * every person in that tense keeps a non-empty ending.
+ * @param {object} verb
+ * @returns {Record<string, string>}
+ */
+export function buildStems(verb) {
+  const stems = {};
+  TENSES.forEach(({ key }) => {
+    const forms = Object.values(verb?.conj?.[key] || {});
+    if (forms.length < 2) return;
+    const prefix = longestCommonPrefix(forms);
+    const shortest = forms.reduce((min, form) => Math.min(min, form.length), Infinity);
+    const stem = prefix.slice(0, Math.min(prefix.length, shortest - 1));
+    if (stem.length >= MIN_STEM_LENGTH) stems[key] = stem;
+  });
+  return stems;
+}
+
+function longestCommonPrefix(values) {
+  if (!values.length) return '';
+  return values.reduce((prefix, value) => {
+    let index = 0;
+    while (index < prefix.length && index < value.length && prefix[index] === value[index]) {
+      index += 1;
+    }
+    return prefix.slice(0, index);
+  });
+}
+
+/**
+ * Build a two-chip assembly task (stem + ending). Tenses are tried in turn and
+ * null is returned when no tense yields a splittable form.
+ */
+export function buildAssembleTask(verb, options = {}) {
+  const { tense, person, rng = Math.random } = options;
+  const stems = buildStems(verb);
+  const available = Object.keys(stems);
+  if (!available.length) return null;
+
+  const order = tense && stems[tense] ? [tense] : shuffle(available, rng);
+  for (const tenseKey of order) {
+    const task = assembleForTense(verb, tenseKey, stems, person, rng);
+    if (task) return task;
+  }
+  return null;
+}
+
+function assembleForTense(verb, tenseKey, stems, person, rng) {
+  const stem = stems[tenseKey];
+  const forms = verb.conj[tenseKey];
+  const persons = PERSONS.map((entry) => entry.key).filter(
+    (key) => forms[key] && forms[key].startsWith(stem) && forms[key].length > stem.length,
+  );
+  if (!persons.length) return null;
+
+  const scoped = person && persons.includes(person) ? [person] : persons;
+  const targetPerson = pickRandom(scoped, rng);
+  const answer = forms[targetPerson];
+  const ending = answer.slice(stem.length);
+
+  const endingOptions = collectUnique(
+    persons.filter((key) => key !== targetPerson).map((key) => forms[key].slice(stem.length)),
+    ending,
+    OPTION_COUNT - 1,
+  );
+  if (!endingOptions.length) return null;
+
+  const stemOptions = collectUnique(
+    Object.entries(stems)
+      .filter(([key]) => key !== tenseKey)
+      .map(([, value]) => value),
+    stem,
+    2,
+  );
+
+  return {
+    stage: STAGES.BUILD,
+    verbId: verb.id,
+    tense: tenseKey,
+    person: targetPerson,
+    promptLabel: 'Saliec formu no daļām',
+    prompt: verb.lv,
+    pronoun: pronounFor(targetPerson),
+    tenseLabel: tenseLabel(tenseKey),
+    answer,
+    stem,
+    ending,
+    stemOptions: shuffle([stem, ...stemOptions], rng),
+    endingOptions: shuffle([ending, ...endingOptions], rng),
+    speakText: answer,
+  };
+}
+
+const FALLBACK_CHAIN = {
+  [STAGES.MEANING]: [STAGES.MEANING],
+  [STAGES.FORM]: [STAGES.FORM, STAGES.MEANING],
+  [STAGES.BUILD]: [STAGES.BUILD, STAGES.FORM, STAGES.MEANING],
+};
+
+/**
+ * Build the task for a verb at its current stage, stepping down the ladder when
+ * the dataset cannot support the requested stage.
+ */
+export function buildTask(verb, pool, options = {}) {
+  const { stage = STAGES.MEANING, language = 'en', rng = Math.random } = options;
+  const chain = FALLBACK_CHAIN[stage] || FALLBACK_CHAIN[STAGES.MEANING];
+  for (const step of chain) {
+    let task = null;
+    if (step === STAGES.BUILD) task = buildAssembleTask(verb, { rng });
+    else if (step === STAGES.FORM) task = buildFormTask(verb, { rng });
+    else task = buildMeaningTask(verb, pool, { language, rng });
+    if (task) return { ...task, lv: verb.lv, translation: getTranslation(verb, language) };
+  }
+  return null;
+}
+
+export function isCorrectChoice(value, task) {
+  return Boolean(task) && normalizeAnswer(value) === normalizeAnswer(task.answer);
+}
+
+export function isCorrectAssembly(stem, ending, task) {
+  return Boolean(task) && normalizeAnswer(`${stem}${ending}`) === normalizeAnswer(task.answer);
+}
+
+export function calculateAccuracy(correct, answered) {
+  if (!answered) return 0;
+  return Math.round((correct / answered) * 100);
+}
+
+/**
+ * Harder stages pay more, and a running streak adds a capped bonus.
+ */
+export function xpForAnswer(stage, streak = 0) {
+  const base = XP_BY_STAGE[stage] || XP_BY_STAGE[STAGES.MEANING];
+  return base + clamp(Math.floor(streak), 0, STREAK_BONUS_CAP) * 2;
+}
+
+/**
+ * Continue the daily streak on consecutive local calendar days, keep it on a
+ * repeat visit, and reset to 1 after any gap.
+ */
+export function computeDailyStreak(lastPlayedISO, currentStreak = 0, now = Date.now()) {
+  const today = toDayNumber(now);
+  const last = lastPlayedISO ? toDayNumber(Date.parse(lastPlayedISO)) : NaN;
+  const streak = Math.max(1, Math.floor(currentStreak) || 0);
+  if (!Number.isFinite(last)) return 1;
+  if (last === today) return streak;
+  if (today - last === 1) return streak + 1;
+  return 1;
+}
+
+function toDayNumber(timestamp) {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return NaN;
+  return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / DAY);
+}
+
+/**
+ * Describe the answer. The correct case stays free of praise because the
+ * feedback sheet already carries the verdict in its title.
+ */
+export function buildExplanation(task, correct) {
+  if (!task) return '';
+  // A meaning pair already spells the answer out, so it needs no prefix.
+  if (task.stage === STAGES.MEANING) {
+    return `${task.lv} — ${task.translation}.`;
+  }
+  const head = correct ? '' : `Pareizā atbilde: ${task.answer}. `;
+  const context = `${task.pronoun} · ${task.tenseLabel} — ${task.lv} (${task.translation}).`;
+  if (task.stage === STAGES.BUILD) {
+    return `${head}${context} Sakne ${task.stem} + galotne ${task.ending}.`;
+  }
+  return `${head}${context}`;
+}
+
+function collectUnique(values, exclude, limit) {
+  const seen = new Set([normalizeAnswer(exclude)]);
+  const picked = [];
+  values.forEach((value) => {
+    if (picked.length >= limit) return;
+    const text = sanitizeText(value);
+    const key = normalizeAnswer(text);
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    picked.push(text);
+  });
+  return picked;
+}

--- a/src/games/darbibas-vardi-v2/styles.css
+++ b/src/games/darbibas-vardi-v2/styles.css
@@ -1,0 +1,963 @@
+/* Darbības Vārdi V2 — mobile-first adaptive verb trainer. */
+
+.dv2-page {
+  --dv2-bg: #f4f6fb;
+  --dv2-ink: #171630;
+  --dv2-muted: #5a5b78;
+  --dv2-surface: #ffffff;
+  --dv2-surface-2: #eef0fb;
+  --dv2-line: #dcdff1;
+  --dv2-brand: #4f46e5;
+  --dv2-brand-strong: #4338ca;
+  --dv2-brand-soft: rgba(79, 70, 229, 0.1);
+  --dv2-on-brand: #ffffff;
+  --dv2-accent: #d97706;
+  --dv2-success: #15803d;
+  --dv2-success-soft: rgba(21, 128, 61, 0.12);
+  --dv2-error: #be123c;
+  --dv2-error-soft: rgba(190, 18, 60, 0.12);
+  --dv2-shadow: rgba(23, 22, 48, 0.1);
+  --dv2-shadow-strong: rgba(23, 22, 48, 0.22);
+  --dv2-radius: 18px;
+  --dv2-radius-sm: 12px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(79, 70, 229, 0.16), transparent 42%),
+    radial-gradient(circle at 88% 8%, rgba(217, 119, 6, 0.14), transparent 40%),
+    var(--dv2-bg);
+  background-attachment: fixed;
+}
+
+[data-bs-theme='dark'] .dv2-page {
+  --dv2-bg: #0d0f1c;
+  --dv2-ink: #ecebfd;
+  --dv2-muted: #a6a8ca;
+  --dv2-surface: #161a2e;
+  --dv2-surface-2: #1e2440;
+  --dv2-line: #313a5e;
+  --dv2-brand: #9b8cff;
+  --dv2-brand-strong: #b4a7ff;
+  --dv2-brand-soft: rgba(155, 140, 255, 0.18);
+  --dv2-on-brand: #12132a;
+  --dv2-accent: #fbbf24;
+  --dv2-success: #5fd693;
+  --dv2-success-soft: rgba(95, 214, 147, 0.16);
+  --dv2-error: #fb7185;
+  --dv2-error-soft: rgba(251, 113, 133, 0.16);
+  --dv2-shadow: rgba(0, 0, 0, 0.34);
+  --dv2-shadow-strong: rgba(0, 0, 0, 0.52);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(155, 140, 255, 0.16), transparent 42%),
+    radial-gradient(circle at 88% 8%, rgba(251, 191, 36, 0.1), transparent 40%),
+    var(--dv2-bg);
+  background-attachment: fixed;
+}
+
+.dv2-page main {
+  min-height: calc(100svh - 130px);
+}
+
+.dv2-app {
+  display: grid;
+  width: min(100%, 780px);
+  margin-inline: auto;
+  padding: 1rem 1rem max(1.25rem, env(safe-area-inset-bottom));
+  color: var(--dv2-ink);
+  font-family: var(--font-body);
+}
+
+.dv2-app [hidden] {
+  display: none !important;
+}
+
+.dv2-app button {
+  font-family: inherit;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.dv2-error {
+  margin-block-end: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--dv2-error);
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-error-soft);
+  color: var(--dv2-error);
+  font-weight: 700;
+}
+
+/* ---------- Shared blocks ---------- */
+
+.dv2-screen {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  align-content: start;
+}
+
+.dv2-hero {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dv2-eyebrow {
+  color: var(--dv2-brand);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dv2-title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: clamp(2rem, 8vw, 2.6rem);
+  font-weight: 850;
+  line-height: 1.05;
+  color: var(--dv2-ink);
+}
+
+.dv2-lead {
+  margin: 0;
+  max-width: 40rem;
+  color: var(--dv2-muted);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.dv2-panel {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: var(--dv2-radius);
+  background: var(--dv2-surface);
+  box-shadow: 0 10px 26px -22px var(--dv2-shadow-strong);
+}
+
+.dv2-panel__title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dv2-muted);
+}
+
+.dv2-note {
+  margin: 0;
+  color: var(--dv2-muted);
+  font-size: 0.9rem;
+}
+
+.dv2-primary,
+.dv2-ghost {
+  min-height: 3.25rem;
+  padding: 0.85rem 1.4rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 1.02rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    transform 0.14s ease,
+    background 0.14s ease,
+    box-shadow 0.14s ease;
+}
+
+.dv2-primary {
+  background: var(--dv2-brand);
+  color: var(--dv2-on-brand);
+  box-shadow: 0 12px 24px -16px var(--dv2-shadow-strong);
+}
+
+.dv2-primary:hover:not(:disabled) {
+  background: var(--dv2-brand-strong);
+}
+
+.dv2-primary:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.dv2-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dv2-ghost {
+  border-color: var(--dv2-line);
+  background: transparent;
+  color: var(--dv2-muted);
+}
+
+.dv2-ghost:hover {
+  background: var(--dv2-surface-2);
+  color: var(--dv2-ink);
+}
+
+.dv2-app :focus-visible {
+  outline: 3px solid var(--dv2-brand);
+  outline-offset: 2px;
+}
+
+.dv2-icon-btn {
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 1px solid var(--dv2-line);
+  border-radius: 50%;
+  background: var(--dv2-surface);
+  color: var(--dv2-ink);
+  cursor: pointer;
+}
+
+.dv2-icon-btn--soft {
+  border-color: transparent;
+  background: var(--dv2-brand-soft);
+  color: var(--dv2-brand);
+}
+
+.dv2-icon-btn[aria-pressed='true'] {
+  background: var(--dv2-brand);
+  color: var(--dv2-on-brand);
+}
+
+.dv2-icon-btn svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ---------- Start screen ---------- */
+
+.dv2-stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.6rem;
+}
+
+.dv2-stat {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.8rem 0.5rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface);
+  text-align: center;
+}
+
+.dv2-stat strong {
+  font-size: 1.5rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.dv2-stat span {
+  color: var(--dv2-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dv2-deck-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+}
+
+.dv2-deck-cell {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface-2);
+}
+
+.dv2-deck-cell strong {
+  font-size: 1.35rem;
+  font-weight: 850;
+  line-height: 1.1;
+}
+
+.dv2-deck-cell span {
+  color: var(--dv2-muted);
+  font-size: 0.8rem;
+}
+
+.dv2-deck-cell--due {
+  background: var(--dv2-brand-soft);
+}
+
+.dv2-deck-cell--due strong {
+  color: var(--dv2-brand);
+}
+
+.dv2-mastery {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--dv2-surface-2);
+  overflow: hidden;
+}
+
+.dv2-mastery span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--dv2-brand), var(--dv2-accent));
+  transition: width 0.4s ease;
+}
+
+.dv2-ladder {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: dv2-step;
+}
+
+.dv2-ladder li {
+  display: grid;
+  grid-template-columns: 1.9rem 1fr;
+  gap: 0.15rem 0.75rem;
+  align-items: baseline;
+  counter-increment: dv2-step;
+}
+
+.dv2-ladder li::before {
+  content: counter(dv2-step);
+  grid-row: span 2;
+  display: grid;
+  place-items: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 50%;
+  background: var(--dv2-brand-soft);
+  color: var(--dv2-brand);
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+.dv2-ladder strong {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.dv2-ladder span {
+  color: var(--dv2-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.dv2-setting {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.dv2-setting__label {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.dv2-segment {
+  display: inline-flex;
+  padding: 0.2rem;
+  border-radius: 999px;
+  background: var(--dv2-surface-2);
+}
+
+.dv2-segment__btn {
+  min-height: 2.5rem;
+  padding: 0.35rem 1rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--dv2-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dv2-segment__btn[aria-pressed='true'] {
+  background: var(--dv2-surface);
+  color: var(--dv2-ink);
+  box-shadow: 0 6px 14px -10px var(--dv2-shadow-strong);
+}
+
+.dv2-switch {
+  display: inline-flex;
+  gap: 0.6rem;
+  align-items: center;
+  min-height: 2.75rem;
+  padding: 0.35rem 0.9rem 0.35rem 0.4rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: 999px;
+  background: var(--dv2-surface);
+  color: var(--dv2-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dv2-switch__track {
+  position: relative;
+  width: 2.6rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--dv2-surface-2);
+  transition: background 0.16s ease;
+}
+
+.dv2-switch__track::after {
+  content: '';
+  position: absolute;
+  inset-block-start: 0.2rem;
+  inset-inline-start: 0.2rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  background: var(--dv2-muted);
+  transition:
+    transform 0.16s ease,
+    background 0.16s ease;
+}
+
+.dv2-switch[aria-pressed='true'] {
+  border-color: var(--dv2-brand);
+  color: var(--dv2-brand);
+}
+
+.dv2-switch[aria-pressed='true'] .dv2-switch__track {
+  background: var(--dv2-brand-soft);
+}
+
+.dv2-switch[aria-pressed='true'] .dv2-switch__track::after {
+  transform: translateX(1.1rem);
+  background: var(--dv2-brand);
+}
+
+.dv2-cta {
+  display: grid;
+  gap: 0.6rem;
+}
+
+/* ---------- Play screen ---------- */
+
+.dv2-play {
+  padding-block-end: 7.5rem;
+}
+
+.dv2-hud {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  position: sticky;
+  inset-block-start: 0.5rem;
+  z-index: 5;
+  padding: 0.6rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: var(--dv2-radius);
+  background: color-mix(in srgb, var(--dv2-surface) 88%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.dv2-hud__main {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.dv2-hud__line {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+}
+
+.dv2-stage-chip {
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: var(--dv2-brand-soft);
+  color: var(--dv2-brand);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dv2-progress {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--dv2-surface-2);
+  overflow: hidden;
+}
+
+.dv2-progress span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--dv2-brand);
+  transition: width 0.28s ease;
+}
+
+.dv2-mini-stats {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.dv2-mini-stats span {
+  display: grid;
+  text-align: center;
+}
+
+.dv2-mini-stats small {
+  color: var(--dv2-muted);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dv2-mini-stats strong {
+  font-size: 1.05rem;
+  font-weight: 850;
+  line-height: 1.1;
+}
+
+.dv2-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.1rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: var(--dv2-radius);
+  background: var(--dv2-surface);
+  box-shadow: 0 18px 40px -32px var(--dv2-shadow-strong);
+  touch-action: pan-y;
+}
+
+.dv2-card[data-swipe='true'] {
+  transition: transform 0.18s ease;
+  transform: translateX(-8px);
+}
+
+.dv2-card__head {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dv2-prompt-label {
+  margin: 0;
+  color: var(--dv2-muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dv2-prompt {
+  margin: 0;
+  font-size: clamp(1.75rem, 7.5vw, 2.4rem);
+  font-weight: 850;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.dv2-context {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.dv2-chip {
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: var(--dv2-surface-2);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.dv2-chip--tense {
+  background: color-mix(in srgb, var(--dv2-accent) 18%, transparent);
+  color: var(--dv2-accent);
+}
+
+.dv2-options {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.dv2-option {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  min-height: 3.5rem;
+  padding: 0.75rem 1rem;
+  border: 1.5px solid var(--dv2-line);
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface);
+  color: var(--dv2-ink);
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-align: start;
+  cursor: pointer;
+  transition:
+    border-color 0.14s ease,
+    background 0.14s ease,
+    transform 0.14s ease;
+}
+
+.dv2-option:hover:not(:disabled) {
+  border-color: var(--dv2-brand);
+}
+
+.dv2-option:active:not(:disabled) {
+  transform: scale(0.99);
+}
+
+.dv2-option__key {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 8px;
+  background: var(--dv2-surface-2);
+  color: var(--dv2-muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.dv2-option__text {
+  overflow-wrap: anywhere;
+}
+
+.dv2-option--correct {
+  border-color: var(--dv2-success);
+  background: var(--dv2-success-soft);
+  color: var(--dv2-success);
+}
+
+.dv2-option--wrong {
+  border-color: var(--dv2-error);
+  background: var(--dv2-error-soft);
+  color: var(--dv2-error);
+}
+
+.dv2-option:disabled {
+  cursor: default;
+}
+
+.dv2-option:disabled:not(.dv2-option--correct):not(.dv2-option--wrong) {
+  opacity: 0.55;
+}
+
+/* ---------- Build stage ---------- */
+
+.dv2-builder {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.dv2-builder__preview {
+  display: flex;
+  gap: 0;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0.9rem 0.75rem;
+  border: 1.5px dashed var(--dv2-line);
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface-2);
+  font-size: clamp(1.3rem, 6vw, 1.8rem);
+  font-weight: 850;
+}
+
+.dv2-slot[data-empty='true'] {
+  margin-inline: 0.2rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--dv2-surface);
+  color: var(--dv2-muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dv2-slot[data-empty='false'] {
+  color: var(--dv2-ink);
+}
+
+.dv2-slot--ending[data-empty='false'] {
+  color: var(--dv2-brand);
+}
+
+.dv2-chip-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.dv2-part {
+  min-height: 3rem;
+  padding: 0.6rem 1.1rem;
+  border: 1.5px solid var(--dv2-line);
+  border-radius: 999px;
+  background: var(--dv2-surface);
+  color: var(--dv2-ink);
+  font-size: 1.05rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition:
+    border-color 0.14s ease,
+    background 0.14s ease;
+}
+
+.dv2-part[aria-pressed='true'] {
+  border-color: var(--dv2-brand);
+  background: var(--dv2-brand-soft);
+  color: var(--dv2-brand);
+}
+
+.dv2-part:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.dv2-hint {
+  margin: 0;
+  color: var(--dv2-muted);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.dv2-hint__touch {
+  display: none;
+}
+
+@media (pointer: coarse) {
+  .dv2-hint__touch {
+    display: inline;
+  }
+
+  .dv2-hint__keys,
+  .dv2-option__key {
+    display: none;
+  }
+}
+
+/* ---------- Feedback sheet ---------- */
+
+.dv2-feedback {
+  position: fixed;
+  inset-inline: 0;
+  inset-block-end: 0;
+  z-index: 20;
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  width: min(100%, 780px);
+  margin-inline: auto;
+  padding: 1rem 1rem max(1rem, env(safe-area-inset-bottom));
+  border-block-start: 1px solid var(--dv2-line);
+  border-start-start-radius: var(--dv2-radius);
+  border-start-end-radius: var(--dv2-radius);
+  background: var(--dv2-surface);
+  box-shadow: 0 -14px 34px -24px var(--dv2-shadow-strong);
+  animation: dv2-sheet-up 0.22s ease;
+}
+
+.dv2-feedback__body {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.dv2-feedback__title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 1.1rem;
+  font-weight: 850;
+}
+
+.dv2-feedback__text {
+  margin: 0.15rem 0 0;
+  color: var(--dv2-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.dv2-feedback[data-result='correct'] .dv2-feedback__title {
+  color: var(--dv2-success);
+}
+
+.dv2-feedback[data-result='wrong'] .dv2-feedback__title {
+  color: var(--dv2-error);
+}
+
+.dv2-feedback .dv2-primary {
+  flex: 0 0 auto;
+  min-width: 7.5rem;
+}
+
+@keyframes dv2-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+/* ---------- Summary ---------- */
+
+.dv2-ring {
+  display: grid;
+  place-content: center;
+  gap: 0.15rem;
+  justify-items: center;
+  aspect-ratio: 1;
+  width: min(58vw, 190px);
+  margin-inline: auto;
+  border-radius: 50%;
+  /* The radial layer paints first, punching the donut hole out of the conic dial. */
+  background:
+    radial-gradient(closest-side, var(--dv2-surface) 78%, transparent 79%),
+    conic-gradient(var(--dv2-brand) calc(var(--dv2-accuracy, 0) * 1%), var(--dv2-surface-2) 0);
+}
+
+.dv2-ring strong {
+  font-size: 2rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.dv2-ring span {
+  color: var(--dv2-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dv2-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.dv2-summary-grid > div {
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--dv2-line);
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface);
+}
+
+.dv2-summary-grid dt {
+  color: var(--dv2-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.dv2-summary-grid dd {
+  margin: 0.15rem 0 0;
+  font-size: 1.25rem;
+  font-weight: 850;
+}
+
+.dv2-review {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.dv2-review li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--dv2-radius-sm);
+  background: var(--dv2-surface-2);
+  font-size: 0.95rem;
+}
+
+.dv2-review__word {
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.dv2-review__box {
+  flex: 0 0 auto;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.dv2-review__box[data-direction='up'] {
+  background: var(--dv2-success-soft);
+  color: var(--dv2-success);
+}
+
+.dv2-review__box[data-direction='down'] {
+  background: var(--dv2-error-soft);
+  color: var(--dv2-error);
+}
+
+/* ---------- Larger screens ---------- */
+
+@media (min-width: 480px) {
+  .dv2-options {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .dv2-cta {
+    grid-template-columns: 1fr auto;
+    justify-content: start;
+  }
+}
+
+@media (min-width: 720px) {
+  .dv2-app {
+    padding-block: 1.5rem;
+  }
+
+  .dv2-deck-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .dv2-summary-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dv2-app *,
+  .dv2-app *::before,
+  .dv2-app *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
  * CACHE_VERSION must be bumped on every release so the activate event
  * can purge stale caches.
  */
-const CACHE_VERSION = 'v22';
+const CACHE_VERSION = 'v23';
 const CACHE_NAME = `llb1-cache-${CACHE_VERSION}`;
 
 /**
@@ -31,14 +31,18 @@ const CORE_ASSETS = [
   './assets/icons/apple-touch-icon.png',
   './assets/icons/icon-192.png',
   './assets/icons/icon-512.png',
+  './src/lib/aria.js',
   './src/lib/constants.js',
   './src/lib/dom.js',
   './src/lib/errors.js',
+  './src/lib/loading.js',
   './src/lib/paths.js',
   './src/lib/safeHtml.js',
+  './src/lib/sanitize.js',
   './src/lib/state.js',
   './src/lib/storage.js',
   './src/lib/utils.js',
+  './src/lib/words-data.js',
   './src/lib/render.js',
   './src/lib/reward.js',
   './src/lib/match.js',
@@ -46,6 +50,7 @@ const CORE_ASSETS = [
   './character-traits.html',
   './conjugation-sprint.html',
   './darbibas-vards.html',
+  './darbibas-vardi-v2.html',
   './decl6-detective.html',
   './duty-dispatcher.html',
   './english-latvian-arcade.html',
@@ -66,6 +71,9 @@ const CORE_ASSETS = [
   './src/games/character-traits/index.js',
   './src/games/character-traits-expansion/index.js',
   './src/games/character-traits-match/index.js',
+  './src/games/darbibas-vardi-v2/index.js',
+  './src/games/darbibas-vardi-v2/logic.js',
+  './src/games/darbibas-vardi-v2/styles.css',
   './src/games/decl6-detective/index.js',
   './src/games/duty-dispatcher/index.js',
   './src/games/english-latvian-arcade/index.js',

--- a/test/games/darbibas-vardi-v2/logic.test.js
+++ b/test/games/darbibas-vardi-v2/logic.test.js
@@ -1,0 +1,427 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  MAX_BOX,
+  STAGES,
+  applyResult,
+  buildAssembleTask,
+  buildExplanation,
+  buildFormTask,
+  buildMeaningTask,
+  buildRound,
+  buildStems,
+  buildTask,
+  calculateAccuracy,
+  computeDailyStreak,
+  describeDeck,
+  hasConjugation,
+  isCorrectAssembly,
+  isCorrectChoice,
+  normalizeRecords,
+  normalizeVerbs,
+  stageForBox,
+  stageForVerb,
+  xpForAnswer,
+} from '../../../src/games/darbibas-vardi-v2/logic.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const html = readFileSync(resolve(__dirname, '../../../darbibas-vardi-v2.html'), 'utf8');
+const homepageScript = readFileSync(resolve(__dirname, '../../../scripts/homepage.js'), 'utf8');
+const navConfig = readFileSync(resolve(__dirname, '../../../scripts/nav-config.js'), 'utf8');
+const serviceWorker = readFileSync(resolve(__dirname, '../../../sw.js'), 'utf8');
+
+function seededRng(seed = 1) {
+  let value = seed >>> 0;
+  return () => {
+    value = (value * 1664525 + 1013904223) >>> 0;
+    return value / 4294967296;
+  };
+}
+
+const RAW_VERBS = [
+  {
+    lv: 'abonēt',
+    en: 'to subscribe',
+    ru: 'подписываться',
+    conj: {
+      present: {
+        '1s': 'abonēju',
+        '2s': 'abonē',
+        '3s': 'abonē',
+        '1p': 'abonējam',
+        '2p': 'abonējat',
+        '3p': 'abonē',
+      },
+      past: {
+        '1s': 'abonēju',
+        '2s': 'abonēji',
+        '3s': 'abonēja',
+        '1p': 'abonējām',
+        '2p': 'abonējāt',
+        '3p': 'abonēja',
+      },
+      future: {
+        '1s': 'abonēšu',
+        '2s': 'abonēsi',
+        '3s': 'abonēs',
+        '1p': 'abonēsim',
+        '2p': 'abonēsiet',
+        '3p': 'abonēs',
+      },
+    },
+  },
+  {
+    lv: 'iet',
+    en: 'to go',
+    ru: 'идти',
+    conj: {
+      present: { '1s': 'eju', '2s': 'ej', '3s': 'iet', '1p': 'ejam', '2p': 'ejat', '3p': 'iet' },
+      past: {
+        '1s': 'gāju',
+        '2s': 'gāji',
+        '3s': 'gāja',
+        '1p': 'gājām',
+        '2p': 'gājāt',
+        '3p': 'gāja',
+      },
+      future: {
+        '1s': 'iešu',
+        '2s': 'iesi',
+        '3s': 'ies',
+        '1p': 'iesim',
+        '2p': 'iesiet',
+        '3p': 'ies',
+      },
+    },
+  },
+  { lv: 'lasīt', en: 'to read', ru: 'читать' },
+  { lv: 'rakstīt', en: 'to write', ru: 'писать' },
+  { lv: 'runāt', en: 'to speak', ru: 'говорить' },
+];
+
+const verbs = normalizeVerbs(RAW_VERBS);
+const abonet = verbs[0];
+const iet = verbs[1];
+const lasit = verbs[2];
+
+test('darbibas vardi v2 page exposes the elements the game wires up', () => {
+  assert.ok(html.includes('<title>Darbības Vārdi V2 — Latvian B Level</title>'));
+  [
+    'dv2-error',
+    'dv2-live',
+    'dv2-xp',
+    'dv2-daily-streak',
+    'dv2-best-streak',
+    'dv2-due-count',
+    'dv2-learning-count',
+    'dv2-mastered-count',
+    'dv2-fresh-count',
+    'dv2-mastery-bar',
+    'dv2-deck-note',
+    'dv2-speech-toggle',
+    'dv2-haptics-toggle',
+    'dv2-start',
+    'dv2-reset',
+    'dv2-quit',
+    'dv2-stage-label',
+    'dv2-progress',
+    'dv2-progress-bar',
+    'dv2-progress-text',
+    'dv2-round-xp',
+    'dv2-streak',
+    'dv2-card',
+    'dv2-prompt-label',
+    'dv2-prompt',
+    'dv2-speak',
+    'dv2-context',
+    'dv2-pronoun',
+    'dv2-tense',
+    'dv2-options',
+    'dv2-builder',
+    'dv2-build-stem',
+    'dv2-build-ending',
+    'dv2-stem-options',
+    'dv2-ending-options',
+    'dv2-check',
+    'dv2-feedback',
+    'dv2-feedback-title',
+    'dv2-feedback-text',
+    'dv2-next',
+    'dv2-summary-accuracy',
+    'dv2-summary-score',
+    'dv2-summary-xp',
+    'dv2-summary-streak',
+    'dv2-summary-mastered',
+    'dv2-review',
+    'dv2-replay',
+    'dv2-home',
+  ].forEach((id) => {
+    assert.ok(new RegExp(`id="${id}"`).test(html), `missing id ${id}`);
+  });
+  ['data-screen="start"', 'data-screen="play"', 'data-screen="summary"'].forEach((marker) => {
+    assert.ok(html.includes(marker), `missing ${marker}`);
+  });
+  assert.ok(html.includes('data-language="en"'));
+  assert.ok(html.includes('data-language="ru"'));
+});
+
+test('darbibas vardi v2 is registered in navigation, homepage, and offline cache', () => {
+  assert.ok(navConfig.includes("{ href: 'darbibas-vardi-v2.html', label: 'Darbības Vārdi V2' }"));
+  assert.ok(homepageScript.includes("title: 'Darbības Vārdi V2'"));
+  assert.ok(homepageScript.includes("href: 'darbibas-vardi-v2.html'"));
+  [
+    './darbibas-vardi-v2.html',
+    './src/games/darbibas-vardi-v2/index.js',
+    './src/games/darbibas-vardi-v2/logic.js',
+    './src/games/darbibas-vardi-v2/styles.css',
+    './src/lib/words-data.js',
+  ].forEach((asset) => {
+    assert.ok(serviceWorker.includes(`'${asset}'`), `missing cached asset ${asset}`);
+  });
+});
+
+test('normalizeVerbs keeps usable rows and drops the rest', () => {
+  const normalized = normalizeVerbs([
+    ...RAW_VERBS,
+    { lv: 'abonēt', en: 'duplicate' },
+    { lv: '', en: 'no lemma' },
+    { lv: 'nezināms' },
+    null,
+  ]);
+  assert.equal(normalized.length, RAW_VERBS.length);
+  assert.equal(normalized[0].id, 'abonēt');
+  assert.equal(normalized[0].conj.present['1s'], 'abonēju');
+  assert.deepEqual(normalized[2].conj, {});
+});
+
+test('conjugation availability gates the form and build stages', () => {
+  assert.equal(hasConjugation(abonet), true);
+  assert.equal(hasConjugation(lasit), false);
+  assert.equal(stageForBox(0), STAGES.MEANING);
+  assert.equal(stageForBox(1), STAGES.MEANING);
+  assert.equal(stageForBox(2), STAGES.FORM);
+  assert.equal(stageForBox(4), STAGES.BUILD);
+  assert.equal(stageForVerb(abonet, { box: 3 }), STAGES.BUILD);
+  assert.equal(stageForVerb(lasit, { box: 3 }), STAGES.MEANING);
+  assert.equal(stageForVerb(abonet, undefined), STAGES.MEANING);
+});
+
+test('applyResult promotes on success and resets the box on a miss', () => {
+  const now = 1_000_000;
+  const first = applyResult(undefined, true, now);
+  assert.equal(first.box, 1);
+  assert.equal(first.seen, 1);
+  assert.equal(first.correct, 1);
+  assert.ok(first.dueAt > now);
+
+  const second = applyResult(first, false, now);
+  assert.equal(second.box, 0);
+  assert.equal(second.wrong, 1);
+  assert.equal(second.dueAt, now, 'box 0 stays due so misses return in the same session');
+
+  let record = { box: MAX_BOX, dueAt: 0, seen: 9, correct: 9, wrong: 0 };
+  record = applyResult(record, true, now);
+  assert.equal(record.box, MAX_BOX, 'box is capped');
+});
+
+test('normalizeRecords repairs corrupt persisted data', () => {
+  const records = normalizeRecords({
+    good: { box: 2, dueAt: 500, seen: 3, correct: 2, wrong: 1 },
+    clamped: { box: 99, dueAt: -5, seen: 'x', correct: null, wrong: 1.9 },
+    broken: 'nope',
+  });
+  assert.deepEqual(records.good, { box: 2, dueAt: 500, seen: 3, correct: 2, wrong: 1 });
+  assert.deepEqual(records.clamped, { box: MAX_BOX, dueAt: 0, seen: 0, correct: 0, wrong: 1 });
+  assert.equal('broken' in records, false);
+  assert.deepEqual(normalizeRecords(null), {});
+});
+
+test('buildRound orders due verbs first, then weak, then unseen', () => {
+  const now = 10_000;
+  const records = {
+    abonēt: { box: 1, dueAt: now - 100, seen: 4, correct: 3, wrong: 1 },
+    iet: { box: 1, dueAt: now - 900, seen: 2, correct: 1, wrong: 1 },
+    lasīt: { box: 1, dueAt: now + 5_000, seen: 5, correct: 1, wrong: 4 },
+    rakstīt: { box: 3, dueAt: now + 9_000, seen: 6, correct: 6, wrong: 0 },
+  };
+  const round = buildRound(verbs, records, { size: 5, now, rng: seededRng(7) });
+  assert.deepEqual(
+    round.map((verb) => verb.id),
+    ['iet', 'abonēt', 'lasīt', 'rakstīt', 'runāt'],
+  );
+});
+
+test('buildRound still fills a round when nothing is scheduled', () => {
+  const now = 10_000;
+  const records = {};
+  verbs.forEach((verb) => {
+    records[verb.id] = { box: 2, dueAt: now + 60_000, seen: 3, correct: 3, wrong: 0 };
+  });
+  const round = buildRound(verbs, records, { size: 3, now, rng: seededRng(3) });
+  assert.equal(round.length, 3);
+  assert.deepEqual(buildRound([], records, { now }), []);
+});
+
+test('buildRound leads with reviews and caps how many unseen verbs join', () => {
+  const now = 10_000;
+  const records = {
+    abonēt: { box: 1, dueAt: now + 60_000, seen: 1, correct: 1, wrong: 0 },
+    iet: { box: 3, dueAt: now + 90_000, seen: 4, correct: 4, wrong: 0 },
+    lasīt: { box: 1, dueAt: now + 120_000, seen: 1, correct: 1, wrong: 0 },
+  };
+  const round = buildRound(verbs, records, { size: 3, now, maxNew: 1, rng: seededRng(9) });
+  assert.equal(round.length, 3);
+  assert.equal(round.filter((verb) => !records[verb.id]).length, 1, 'one new verb per round');
+  assert.deepEqual(
+    round.slice(0, 2).map((verb) => verb.id),
+    ['iet', 'abonēt'],
+    'reviews come first, most advanced leading so higher stages get airtime',
+  );
+
+  // The cap relaxes when there is nothing left to review.
+  const emptyDeck = buildRound(verbs, {}, { size: 4, now, maxNew: 1, rng: seededRng(9) });
+  assert.equal(emptyDeck.length, 4);
+});
+
+test('describeDeck counts fresh, learning, due, and mastered verbs', () => {
+  const now = 10_000;
+  const summary = describeDeck(
+    verbs,
+    {
+      abonēt: { box: MAX_BOX, dueAt: now + 10, seen: 8, correct: 8, wrong: 0 },
+      iet: { box: 1, dueAt: now - 10, seen: 2, correct: 1, wrong: 1 },
+    },
+    now,
+  );
+  assert.deepEqual(summary, { total: 5, fresh: 3, learning: 1, due: 1, mastered: 1 });
+});
+
+test('buildMeaningTask fills four unique options that include the answer', () => {
+  const rng = seededRng(11);
+  const task = buildMeaningTask(abonet, verbs, { language: 'en', direction: 'lv-to-tr', rng });
+  assert.equal(task.stage, STAGES.MEANING);
+  assert.equal(task.prompt, 'abonēt');
+  assert.equal(task.answer, 'to subscribe');
+  assert.equal(task.options.length, 4);
+  assert.equal(new Set(task.options).size, 4);
+  assert.ok(task.options.includes(task.answer));
+  assert.equal(task.speakText, 'abonēt');
+
+  const reversed = buildMeaningTask(abonet, verbs, { language: 'ru', direction: 'tr-to-lv', rng });
+  assert.equal(reversed.prompt, 'подписываться');
+  assert.equal(reversed.answer, 'abonēt');
+  assert.ok(reversed.options.includes('abonēt'));
+});
+
+test('buildMeaningTask returns null when the pool cannot fill the options', () => {
+  assert.equal(buildMeaningTask(abonet, [abonet], { rng: seededRng(2) }), null);
+});
+
+test('buildFormTask uses the verb own forms as near-miss distractors', () => {
+  const task = buildFormTask(abonet, { tense: 'past', person: '1s', rng: seededRng(5) });
+  assert.equal(task.stage, STAGES.FORM);
+  assert.equal(task.answer, 'abonēju');
+  assert.equal(task.pronoun, 'es');
+  assert.equal(task.tenseLabel, 'pagātne');
+  assert.equal(task.options.length, 4);
+  assert.equal(new Set(task.options).size, 4);
+  assert.ok(task.options.includes('abonēju'));
+
+  const ownForms = new Set(
+    ['present', 'past', 'future'].flatMap((tense) => Object.values(abonet.conj[tense])),
+  );
+  task.options.forEach((option) => assert.ok(ownForms.has(option), `${option} is not a verb form`));
+});
+
+test('buildStems splits every tense so each person keeps a non-empty ending', () => {
+  const stems = buildStems(abonet);
+  assert.deepEqual(Object.keys(stems).sort(), ['future', 'past', 'present']);
+  Object.entries(stems).forEach(([tense, stem]) => {
+    assert.ok(stem.length >= 2, `${tense} stem is too short`);
+    Object.values(abonet.conj[tense]).forEach((form) => {
+      assert.ok(form.startsWith(stem), `${form} does not start with ${stem}`);
+      assert.ok(form.length > stem.length, `${form} would have an empty ending`);
+    });
+  });
+
+  // "iet" has no shared present prefix, so that tense is skipped entirely.
+  assert.deepEqual(Object.keys(buildStems(iet)).sort(), ['future', 'past']);
+  assert.deepEqual(buildStems(lasit), {});
+});
+
+test('buildAssembleTask produces parts that rebuild the answer', () => {
+  const task = buildAssembleTask(abonet, { tense: 'past', person: '1p', rng: seededRng(13) });
+  assert.equal(task.stage, STAGES.BUILD);
+  assert.equal(task.answer, 'abonējām');
+  assert.equal(`${task.stem}${task.ending}`, task.answer);
+  assert.ok(task.stemOptions.includes(task.stem));
+  assert.ok(task.endingOptions.includes(task.ending));
+  assert.equal(new Set(task.endingOptions).size, task.endingOptions.length);
+  assert.ok(isCorrectAssembly(task.stem, task.ending, task));
+  assert.equal(isCorrectAssembly(task.stem, 'xx', task), false);
+
+  assert.equal(buildAssembleTask(lasit, { rng: seededRng(1) }), null);
+});
+
+test('buildTask steps down the ladder when a stage is impossible', () => {
+  const build = buildTask(abonet, verbs, { stage: STAGES.BUILD, rng: seededRng(21) });
+  assert.equal(build.stage, STAGES.BUILD);
+  assert.equal(build.lv, 'abonēt');
+  assert.equal(build.translation, 'to subscribe');
+
+  const fallback = buildTask(lasit, verbs, { stage: STAGES.BUILD, rng: seededRng(21) });
+  assert.equal(fallback.stage, STAGES.MEANING);
+
+  const russian = buildTask(lasit, verbs, {
+    stage: STAGES.MEANING,
+    language: 'ru',
+    rng: seededRng(4),
+  });
+  assert.equal(russian.translation, 'читать');
+});
+
+test('isCorrectChoice ignores case and stray whitespace', () => {
+  const task = { answer: 'abonēju' };
+  assert.equal(isCorrectChoice('  AbonĒju ', task), true);
+  assert.equal(isCorrectChoice('abonēji', task), false);
+  assert.equal(isCorrectChoice('abonēju', null), false);
+});
+
+test('scoring helpers stay within expected bounds', () => {
+  assert.equal(calculateAccuracy(0, 0), 0);
+  assert.equal(calculateAccuracy(3, 4), 75);
+  assert.equal(xpForAnswer(STAGES.MEANING, 0), 10);
+  assert.equal(xpForAnswer(STAGES.FORM, 2), 19);
+  assert.equal(xpForAnswer(STAGES.BUILD, 99), 30, 'streak bonus is capped');
+  assert.equal(xpForAnswer('unknown', 0), 10);
+});
+
+test('computeDailyStreak grows on consecutive days and resets after a gap', () => {
+  // Midday timestamps keep the local-calendar comparison stable in any timezone.
+  const today = Date.parse('2026-03-10T12:00:00Z');
+  assert.equal(computeDailyStreak('', 0, today), 1);
+  assert.equal(computeDailyStreak('2026-03-10T12:00:00Z', 4, today), 4);
+  assert.equal(computeDailyStreak('2026-03-09T12:00:00Z', 4, today), 5);
+  assert.equal(computeDailyStreak('2026-03-01T12:00:00Z', 4, today), 1);
+  assert.equal(computeDailyStreak('not-a-date', 4, today), 1);
+});
+
+test('buildExplanation names the answer and its grammatical context', () => {
+  const meaning = buildTask(lasit, verbs, { stage: STAGES.MEANING, rng: seededRng(6) });
+  // The pair itself is the explanation, whichever direction was asked.
+  assert.equal(buildExplanation(meaning, true), 'lasīt — to read.');
+  assert.equal(buildExplanation(meaning, false), 'lasīt — to read.');
+
+  const form = buildTask(abonet, verbs, { stage: STAGES.FORM, rng: seededRng(2) });
+  assert.ok(buildExplanation(form, false).startsWith(`Pareizā atbilde: ${form.answer}.`));
+
+  const build = buildTask(abonet, verbs, { stage: STAGES.BUILD, rng: seededRng(9) });
+  const text = buildExplanation(build, false);
+  assert.ok(text.includes(build.stem));
+  assert.ok(text.includes(build.ending));
+  assert.equal(buildExplanation(null, true), '');
+});


### PR DESCRIPTION
## What changed

- Add the Darbības Vārdi V2 adaptive verb trainer page and game implementation.
- Add pure game logic with Leitner-style mastery boxes, meaning/form/build stages, XP, streaks, answer feedback, and persisted progress.
- Add the unit test suite for the new game.
- Register the game in navigation, the homepage catalogue, and the service-worker offline asset list.
- Extend the Playwright page and smoke coverage for the new game.

## User impact

Learners can practise Latvian verbs through progressive meaning, conjugation-form, and stem/ending assembly exercises, with progress preserved across sessions.

## Validation

- Verified the remote branch is based on main with no divergence (ahead by 10, behind by 0).
- Verified the compare diff contains the intended page, source modules, stylesheet, tests, E2E updates, navigation/homepage registration, and service-worker cache update.
- Local Node/Playwright execution was not available because this workspace has no checkout of the repository; GitHub checks should validate the branch after PR creation.